### PR TITLE
Update traceabilitytool to use .NET 4.8 so win11/vs22 works

### DIFF
--- a/traceabilitytool/CMakeLists.txt
+++ b/traceabilitytool/CMakeLists.txt
@@ -26,7 +26,7 @@ set_property(TARGET traceabilitytool
 )
 
 set_property(TARGET traceabilitytool
-    PROPERTY DOTNET_TARGET_FRAMEWORK_VERSION "v4.8"
+    PROPERTY DOTNET_TARGET_FRAMEWORK_VERSION "v4.7.2"
 )
 
 set_property(TARGET traceabilitytool PROPERTY VS_DOTNET_REFERENCES

--- a/traceabilitytool/CMakeLists.txt
+++ b/traceabilitytool/CMakeLists.txt
@@ -26,7 +26,7 @@ set_property(TARGET traceabilitytool
 )
 
 set_property(TARGET traceabilitytool
-    PROPERTY DOTNET_TARGET_FRAMEWORK_VERSION "v4.5"
+    PROPERTY DOTNET_TARGET_FRAMEWORK_VERSION "v4.8"
 )
 
 set_property(TARGET traceabilitytool PROPERTY VS_DOTNET_REFERENCES


### PR DESCRIPTION
I couldn't load this project in a clean win11/vs2022 setup otherwise, and .NET 4.5 doesn't seem to be available anymore.