### PR TITLE
Improve propagate_updates.ps1

### DIFF
--- a/update_deps/build_graph.ps1
+++ b/update_deps/build_graph.ps1
@@ -51,6 +51,11 @@ function get-name-from-url {
     param (
         [string] $url
    )
+   if(!$url.Contains("http"))
+   {
+        Write-Error("Invalid URL: $url")
+        exit -1
+   }
    $split_by_slash = $url.Split('/')
    $split_by_dot = $split_by_slash[-1].Split('.') # $split_by_slash[-1] contains [repo_name].git
    return $split_by_dot[0] # $split_by_dot[0] contains [repo_name]
@@ -161,3 +166,4 @@ $repo_order = New-Object -TypeName "System.Collections.ArrayList"
 # collect repo names in repo_order
 $repo_levels_list.ForEach({$repo_order.Add($args[0].Key)})
 Set-Content -Path .\order.json -Value ($repo_order | ConvertTo-Json)
+Exit 0

--- a/update_deps/dependency_updates_propagation.md
+++ b/update_deps/dependency_updates_propagation.md
@@ -26,10 +26,10 @@ PS> .\{PATH_TO_SCRIPT}\propagate_updates.ps1 -azure_token {token1} -github_token
 ```
 ### Arguments:
 
-- `-azure_token`: Mandatory. Personal access token for Azure Devops Services. Token must have permissions for Code and Work Items.
-- `-github_token`: Mandatory. Personal access token for Github. Token must be authorized for use with the Azure organization on Github.
-- `-azure_work_item`: Optional. Work item id of Azure work item that is linked to PRs made to Azure repos. Only required if Azure repos need to be updated.
-- `-root`: Optional. URL of the repository upto which updates must be propagated. [Azure-MessagingStore](https://msazure.visualstudio.com/DefaultCollection/One/_git/Azure-MessagingStore) by default.
+- `-root`: URL of the repository upto which updates must be propagated.
+- `-github_token`: Personal access token for Github. Token must be authorized for use with the Azure organization on Github.
+- `-azure_token`: Personal access token for Azure Devops Services. Token must have permissions for Code and Work Items.
+- `-azure_work_item`: Work item id of Azure work item that is linked to PRs made to Azure repos. Only required if Azure repos need to be updated.
 
 
 ### ignores.json


### PR DESCRIPTION
These changes address the following issues:

- The script would accept a file path as `-root`. This is undesirable because the script would still work in most cases, unless the remotes for some repositories were set to not be Azure or Github. These changes validate that the value passed to the `-root` argument is a valid URL.
- `-azure_work_item` was optional. If `-azure_work_item` was not provided, the script would fail when it would try to update an Azure repository. These changes make `-azure_work_item` mandatory. This allows the script to fail early if the `-azure_work_item` is not provided. This has the implication that the script cannot be used to only propagate updates to a repository in the middle of dependency graph. Since that is not a common use case, this change is justified.
- `-root` was optional and assumed to be `https://msazure.visualstudio.com/DefaultCollection/One/_git/Azure-MessagingStore`. Now it is mandatory since the script is being used to propagate updates to other top-level projects (ElasticLog, Georeplication).