### PR TITLE
Add vld.ini file which contains ignore functions list 

### DIFF
--- a/build_functions/CMakeLists.txt
+++ b/build_functions/CMakeLists.txt
@@ -160,6 +160,8 @@ macro(set_default_build_options)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address")
     endif()
 
+    configure_file(${build_c_tests_internal_dir}/ignore_function_names_vld.ini $ENV{ProgramFiles\(x86\)}/Visual Leak Detector/vld.ini COPYONLY)
+    
     enable_testing()
 endmacro()
 

--- a/build_functions/CMakeLists.txt
+++ b/build_functions/CMakeLists.txt
@@ -160,8 +160,8 @@ macro(set_default_build_options)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /fsanitize=address")
     endif()
 
-    configure_file(${build_c_tests_internal_dir}/ignore_function_names_vld.ini $ENV{ProgramFiles\(x86\)}/Visual Leak Detector/vld.ini COPYONLY)
-    
+    configure_file("${build_c_tests_internal_dir}/ignore_function_names_vld.ini" "$ENV{ProgramFiles\(x86\)}/Visual Leak Detector/vld.ini" COPYONLY)
+
     enable_testing()
 endmacro()
 

--- a/build_functions/ignore_function_names_vld.ini
+++ b/build_functions/ignore_function_names_vld.ini
@@ -1,0 +1,184 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;;  Visual Leak Detector - Initialization/Configuration File
+;;  Copyright (c) 2005-2017 VLD Team
+;;
+;;  This library is free software; you can redistribute it and/or
+;;  modify it under the terms of the GNU Lesser General Public
+;;  License as published by the Free Software Foundation; either
+;;  version 2.1 of the License, or (at your option) any later version.
+;;
+;;  This library is distributed in the hope that it will be useful,
+;;  but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;;  Lesser General Public License for more details.
+;;
+;;  You should have received a copy of the GNU Lesser General Public
+;;  License along with this library; if not, write to the Free Software
+;;  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+;;
+;;  See COPYING.txt for the full terms of the GNU Lesser General Public License.
+;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; Any options left blank or not present will revert to their default values.
+[Options]
+
+; The main on/off switch. If off, Visual Leak Detector will be completely
+; disabled. It will do nothing but print a message to the debugger indicating
+; that it has been turned off.
+;
+;  Valid Values: on, off
+;  Default: on
+;
+VLD = on
+
+; If yes, duplicate leaks (those that are identical) are not shown individually.
+; Only the first such leak is shown, along with a number indicating the total
+; number of duplicate leaks.
+;
+;   Valid Values: yes, no
+;   Default: no
+;
+AggregateDuplicates = no
+
+; Lists any additional modules to be included in memory leak detection. This can
+; be useful for checking for memory leaks in debug builds of 3rd party modules
+; which can not be easily rebuilt with '#include "vld.h"'. This option should be
+; used only if absolutely necessary and only if you really know what you are
+; doing.
+;
+;   CAUTION: Avoid listing any modules that link with the release CRT libraries.
+;     Only modules that link with the debug CRT libraries should be listed here.
+;     Doing otherwise might result in false memory leak reports or even crashes.
+;
+;   Valid Values: Any list containing module names (i.e. names of EXEs or DLLs)
+;   Default: None.
+;
+ForceIncludeModules = 
+
+; Maximum number of data bytes to display for each leaked block. If zero, then
+; the data dump is completely suppressed and only call stacks are shown.
+; Limiting this to a low number can be useful if any of the leaked blocks are
+; very large and cause unnecessary clutter in the memory leak report.
+;
+;   Value Values: 0 - 4294967295
+;   Default: 256
+;
+MaxDataDump = 
+
+; Maximum number of call stack frames to trace back during leak detection.
+; Limiting this to a low number can reduce the CPU utilization overhead imposed
+; by memory leak detection, especially when using the slower "safe" stack
+; walking method (see StackWalkMethod below).
+;
+;   Valid Values: 1 - 4294967295
+;   Default: 64
+;
+MaxTraceFrames = 
+
+; Sets the type of encoding to use for the generated memory leak report. This
+; option is really only useful in conjuction with sending the report to a file.
+; Sending a Unicode encoded report to the debugger is not useful because the
+; debugger cannot display Unicode characters. Using Unicode encoding might be
+; useful if the data contained in leaked blocks is likely to consist of Unicode
+; text.
+;
+;   Valid Values: ascii, unicode
+;   Default: ascii
+;
+ReportEncoding = ascii
+
+; Sets the report file destination, if reporting to file is enabled. A relative
+; path may be specified and is considered relative to the process' working
+; directory.
+;
+;   Valid Values: Any valid path and filename.
+;   Default: .\memory_leak_report.txt
+;
+ReportFile = 
+
+; Sets the report destination to either a file, the debugger, or both. If
+; reporting to file is enabled, the report is sent to the file specified by the
+; ReportFile option.
+;
+;   Valid Values: debugger, file, both
+;   Default: debugger
+;
+ReportTo = debugger
+
+; Turns on or off a self-test mode which is used to verify that VLD is able to
+; detect memory leaks in itself. Intended to be used for debugging VLD itself,
+; not for debugging other programs.
+;
+;   Valid Values: on, off
+;   Default: off
+;
+SelfTest = off
+
+; Selects the method to be used for walking the stack to obtain stack traces for
+; allocated memory blocks. The "fast" method may not always be able to
+; successfully trace completely through all call stacks. In such cases, the
+; "safe" method may prove to more reliably obtain the full stack trace. The
+; disadvantage is that the "safe" method is significantly slower than the "fast"
+; method and will probably result in very noticeable performance degradation of
+; the program being debugged.
+;
+;   Valid Values: fast, safe
+;   Default: fast
+; 
+StackWalkMethod = fast
+
+; Determines whether memory leak detection should be initially enabled for all
+; threads, or whether it should be initially disabled for all threads. If set
+; to "yes", then any threads requiring memory leak detection to be enabled will
+; need to call VLDEnable at some point to enable leak detection for those
+; threads.
+;
+;   Valid Values: yes, no
+;   Default: no
+;
+StartDisabled = no
+
+; Determines whether or not all frames, including frames internal to the heap,
+; are traced. There will always be a number of frames internal to Visual Leak
+; Detector and C/C++ or Win32 heap APIs that aren't generally useful for
+; determining the cause of a leak. Normally these frames are skipped during the
+; stack trace, which somewhat reduces the time spent tracing and amount of data
+; collected and stored in memory. Including all frames in the stack trace, all
+; the way down into VLD's own code can, however, be useful for debugging VLD
+; itself.
+;
+;   Valid Values: yes, no
+;   Default: no
+;
+TraceInternalFrames = no
+
+; Determines whether or not report memory leaks when missing HeapFree calls.
+;
+;   Valid Values: yes, no
+;   Default: no
+;
+SkipHeapFreeLeaks = no
+
+; Determines whether or not report memory leaks generated from crt startup code.
+; These are not actual memory leaks as they are freed by crt after the VLD object
+; has been destroyed.
+;
+;   Valid Values: yes, no
+;   Default: yes
+;
+SkipCrtStartupLeaks = yes
+
+; Lists any specific functions to be ignored in memory leak detection. This can
+; be useful for false positive functions that report memory leaks especially 
+; when the code is maintained by 3rd party libraries. This option should be
+; used only if absolutely necessary and only if you really know what you are
+; doing.
+;
+;   CAUTION: Avoid listing any function names without manually checking for leaks.
+;
+;   Valid Values: Functions names as strings separated by comma. Strings are case sensitive.
+;   Default: None.
+;
+IgnoreFunctionsList = `anonymous namespace'::GetOSVersion,Azure::Storage::_internal::UrlEncodeQueryParameter,Azure::Storage::_internal::UrlEncodePath,Azure::Core::Url::Decode,Azure::Identity::_detail::TokenCredentialImpl::GetToken


### PR DESCRIPTION
Adds these methods 
1. `anonymous namespace'::GetOSVersion,
2. Azure::Storage::_internal::UrlEncodeQueryParameter,
3. Azure::Storage::_internal::UrlEncodePath,Azure::Core::Url::Decode,
4. Azure::Identity::_detail::TokenCredentialImpl::GetToken

to `IgnoreFunctionsList` in vld.ini file. 

These methods are from sdk and because of these methods our vld reports them as leaks due to static string allocation. 
