### PR TITLE
Add 2 install library functions.

### DIFF
--- a/build_functions/CMakeLists.txt
+++ b/build_functions/CMakeLists.txt
@@ -282,15 +282,14 @@ function(install_library_with_prefix theTarget includePrefix)
         set(CMAKE_INSTALL_LIBDIR "lib")
     endif()
 
-    # Install elastic_log_rpc_client
     set(package_location "cmake")
 
+    # Make an installation build target for theTarget
     install(TARGETS ${theTarget} EXPORT ${theTarget}Targets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
         PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${includePrefix}
     )
-    #install(FILES ${zrpc_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zrpc)
 
 endfunction()
 

--- a/build_functions/CMakeLists.txt
+++ b/build_functions/CMakeLists.txt
@@ -266,3 +266,36 @@ function(add_reals_check_target)
         )
     endif()
 endfunction()
+
+# signature: install_library_with_prefix(<theTarget> <includePrefix> [ <public_header>... ]])
+# Creates an install target for library with a subdirectory and optional public header files.
+function(install_library_with_prefix theTarget includePrefix)
+    
+    if(ARGN)
+        set_target_properties(${theTarget} PROPERTIES PUBLIC_HEADER "${ARGN}")
+    endif()
+
+    # Set CMAKE_INSTALL_* if not defined
+    include(GNUInstallDirs)
+
+    if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+        set(CMAKE_INSTALL_LIBDIR "lib")
+    endif()
+
+    # Install elastic_log_rpc_client
+    set(package_location "cmake")
+
+    install(TARGETS ${theTarget} EXPORT ${theTarget}Targets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR}/../bin
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${includePrefix}
+    )
+    #install(FILES ${zrpc_h_files} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zrpc)
+
+endfunction()
+
+# signature: install_library(<theTarget> [ <public_header>... ]])
+# Creates an install target for library with optional public header files.
+function(install_library theTarget )
+    install_library_with_prefix(${theTarget} "" ${ARGN})
+endfunction()


### PR DESCRIPTION
2 new build functions:

`install_library_with_prefix(<theTarget> <includePrefix> [ <public_header>... ]]) `
Creates an install target for library with an include subdirectory and optional public header files.

`install_library(<theTarget> [ <public_header>... ]]) `
Creates an install target for library with optional public header files.

Example usage:
`install_library_with_prefix(zrpc zrpc ${zrpc_h_files})`