### PR TITLE
Remove the -V option from ctest runs as it is too much logging

### DIFF
--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -104,6 +104,6 @@ jobs:
     displayName: 'Run ctest'
     inputs:
       filename: ctest
-      arguments: '-C "${{ parameters.build_configuration }}" -V --output-on-failure'
+      arguments: '-C "${{ parameters.build_configuration }}" --output-on-failure'
       workingFolder: 'cmake_build'
   


### PR DESCRIPTION
Remove the -V option from ctest runs as it is too much logging