### PR TITLE
Fix a miss on how we pass the parameter for the codeql3000 default yml

### DIFF
--- a/pipeline_templates/codeql3000_default.yml
+++ b/pipeline_templates/codeql3000_default.yml
@@ -57,7 +57,7 @@ jobs:
 
   - template: codeql3000_init.yml
     parameters:
-      repo_root: $(Build.SourcesDirectory)
+      repo_root: ${{ parameters.repo_root }}
 
   - task: CMake@1
     displayName: 'CMake ${{parameters.cmake_command}} -DCMAKE_BUILD_TYPE=${{parameters.configuration}}'


### PR DESCRIPTION
Fix a miss on how we pass the parameter for the codeql3000 default yml