### PR TITLE
Add delete branch option to propagate_updates for the azure devops repos

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -12,7 +12,7 @@ configuration:
     - if:
       - payloadType: Pull_Request
       - filesMatchPattern:
-          pattern: deps/*
+          pattern: ^deps/*
       - isOpen
       then:
       - approvePullRequest:

--- a/update_deps/propagate_updates.ps1
+++ b/update_deps/propagate_updates.ps1
@@ -257,6 +257,7 @@ function set-autocomplete-azure {
         }
         completionOptions=@{
             mergeStrategy="squash"
+            deleteSourceBranch=$true
         }
     }
     $body = $body | ConvertTo-Json


### PR DESCRIPTION
This should help reduce the branches that get left behind in the ADO repos