### PR TITLE
Remove environment variable Build_SourcesDirectory

### DIFF
--- a/sarif_results_checker/CMakeLists.txt
+++ b/sarif_results_checker/CMakeLists.txt
@@ -23,9 +23,9 @@ set_property(TARGET Azure.Messaging.SarifResultsChecker
     PROPERTY DOTNET_TARGET_FRAMEWORK_VERSION "v4.7.2"
 )
 
-if (EXISTS $ENV{Build_SourcesDirectory}/import_for_signing.not_propz_at_all)
+if (EXISTS ${PROJECT_SOURCE_DIR}/import_for_signing.not_propz_at_all)
     set_property(TARGET Azure.Messaging.SarifResultsChecker
-        PROPERTY VS_PROJECT_IMPORT $ENV{Build_SourcesDirectory}/import_for_signing.not_propz_at_all
+        PROPERTY VS_PROJECT_IMPORT ${PROJECT_SOURCE_DIR}/import_for_signing.not_propz_at_all
     )
 endif()
 


### PR DESCRIPTION
We can use the cmake variable `PROJECT_SOURCE_DIR` instead