### PR TITLE
Add TIMED_TEST_SUITE_INITIALIZE/CLEANUP guidelines to coding instructions

### DIFF
--- a/.github/general_coding_instructions.md
+++ b/.github/general_coding_instructions.md
@@ -1127,6 +1127,44 @@ Test helper headers that are used across multiple tests should be included in th
 - This improves build times and reduces include duplication
 - PCH include must be the first include in the test file
 
+### Test Suite Initialize and Cleanup
+
+Test suites must use `TIMED_TEST_SUITE_INITIALIZE` and `TIMED_TEST_SUITE_CLEANUP` from `c_pal/timed_test_suite.h` instead of `TEST_SUITE_INITIALIZE` / `TEST_SUITE_CLEANUP`. The timed versions inject a process watchdog that terminates the test process if a test suite hangs, preventing CI pipelines from stalling indefinitely.
+
+```c
+#include "c_pal/timed_test_suite.h"
+
+// timeout_ms is required - use TIMED_TEST_DEFAULT_TIMEOUT_MS (10 minutes) or a custom value
+TIMED_TEST_SUITE_INITIALIZE(TestSuiteInit, TIMED_TEST_DEFAULT_TIMEOUT_MS)
+{
+    // suite initialization code
+}
+
+TIMED_TEST_SUITE_CLEANUP(TestSuiteCleanup)
+{
+    // suite cleanup code
+}
+```
+
+Additional fixtures can be passed as variadic arguments, just like with the old macros:
+
+```c
+TIMED_TEST_SUITE_INITIALIZE(TestSuiteInit, TIMED_TEST_DEFAULT_TIMEOUT_MS, my_extra_init_fixture)
+{
+    // suite initialization code
+}
+
+TIMED_TEST_SUITE_CLEANUP(TestSuiteCleanup, my_extra_cleanup_fixture)
+{
+    // suite cleanup code
+}
+```
+
+**Guidelines:**
+- Do NOT use `TEST_SUITE_INITIALIZE` or `TEST_SUITE_CLEANUP` directly — they are internal macros and will produce a compile error
+- Always include `c_pal/timed_test_suite.h` instead of `testrunnerswitcher.h` directly
+- Use `TIMED_TEST_DEFAULT_TIMEOUT_MS` (10 minutes) unless a test suite needs a different timeout
+
 ### Include Paths for Reals Headers
 When including real implementation headers in test files, use the header name directly without relative paths. The build system's `reals` target adds the correct include directory:
 


### PR DESCRIPTION
## Summary

Adds a new section to `general_coding_instructions.md` documenting that test suites must use `TIMED_TEST_SUITE_INITIALIZE` and `TIMED_TEST_SUITE_CLEANUP` (from `c_pal/timed_test_suite.h`) instead of the raw `TEST_SUITE_INITIALIZE` / `TEST_SUITE_CLEANUP` macros.

## Why

We are adding a process watchdog to all test suites that terminates the test process if a suite hangs, preventing CI pipelines from stalling indefinitely. The timed wrapper macros inject the watchdog fixtures automatically. The raw `TEST_SUITE_INITIALIZE` / `TEST_SUITE_CLEANUP` macros have been renamed to `_INTERNAL` in c-testrunnerswitcher (see https://github.com/Azure/c-testrunnerswitcher/pull/287) and will produce a compile error if used directly.

## What's documented

- Usage examples with `TIMED_TEST_SUITE_INITIALIZE` / `TIMED_TEST_SUITE_CLEANUP`
- How to pass additional fixtures via variadic arguments
- Guidelines: always include `c_pal/timed_test_suite.h`, use `TIMED_TEST_DEFAULT_TIMEOUT_MS` unless a custom timeout is needed