### PR TITLE
[MrBot] Add skip_master_check parameter and parameterize pool names

### DIFF
--- a/pipeline_templates/build_all_flavors.yml
+++ b/pipeline_templates/build_all_flavors.yml
@@ -57,6 +57,12 @@ parameters:
   - name: failOnMinTestsNotRun
     type: boolean
     default: true
+  - name: pool_name
+    type: string
+    default: "Azure-MessagingStore-WinBuildPoolVS2022_0"
+  - name: pool_name_arm64
+    type: string
+    default: "Azure-MessagingStore-WinBuildPoolARM"
 
 jobs:
 - ${{ each GBALLOC_LL_TYPE in parameters.GBALLOC_LL_TYPE_VALUES }}:
@@ -80,6 +86,8 @@ jobs:
               binary_name_suffix: ${{ parameters.binary_name_suffix }}
               appverifier_skip_tests_list: ${{ parameters.appverifier_skip_tests_list }}
               failOnMinTestsNotRun: ${{ parameters.failOnMinTestsNotRun }}
+              pool_name: ${{ parameters.pool_name }}
+              pool_name_arm64: ${{ parameters.pool_name_arm64 }}
               # ARM64 builds are optional (non-blocking)
               ${{ if eq(ARCH_TYPE, 'ARM64') }}:
                 is_optional: true

--- a/pipeline_templates/build_all_flavors.yml
+++ b/pipeline_templates/build_all_flavors.yml
@@ -57,7 +57,7 @@ parameters:
   - name: failOnMinTestsNotRun
     type: boolean
     default: true
-  - name: pool_name
+  - name: pool_name_x64
     type: string
     default: "Azure-MessagingStore-WinBuildPoolVS2022_0"
   - name: pool_name_arm64
@@ -86,7 +86,7 @@ jobs:
               binary_name_suffix: ${{ parameters.binary_name_suffix }}
               appverifier_skip_tests_list: ${{ parameters.appverifier_skip_tests_list }}
               failOnMinTestsNotRun: ${{ parameters.failOnMinTestsNotRun }}
-              pool_name: ${{ parameters.pool_name }}
+              pool_name_x64: ${{ parameters.pool_name_x64 }}
               pool_name_arm64: ${{ parameters.pool_name_arm64 }}
               # ARM64 builds are optional (non-blocking)
               ${{ if eq(ARCH_TYPE, 'ARM64') }}:

--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -39,7 +39,7 @@ parameters:
   - name: is_optional
     type: boolean
     default: false
-  - name: pool_name
+  - name: pool_name_x64
     type: string
     default: "Azure-MessagingStore-WinBuildPoolVS2022_0"
   - name: pool_name_arm64
@@ -67,7 +67,7 @@ jobs:
       - visualstudio
   ${{ else }}:
     pool:
-      name: ${{ parameters.pool_name }}
+      name: ${{ parameters.pool_name_x64 }}
       demands:
       - msbuild
       - cmake

--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -39,6 +39,12 @@ parameters:
   - name: is_optional
     type: boolean
     default: false
+  - name: pool_name
+    type: string
+    default: "Azure-MessagingStore-WinBuildPoolVS2022_0"
+  - name: pool_name_arm64
+    type: string
+    default: "Azure-MessagingStore-WinBuildPoolARM"
 
 jobs:
 - job: build_and_run_tests_${{ parameters.BUILD_SUFFIX }}
@@ -54,14 +60,14 @@ jobs:
   # ARM64 uses dedicated ARM pool, x64 uses standard pool
   ${{ if eq(parameters.ARCH_TYPE, 'ARM64') }}:
     pool:
-      name: Azure-MessagingStore-WinBuildPoolARM
+      name: ${{ parameters.pool_name_arm64 }}
       demands:
       - msbuild
       - cmake
       - visualstudio
   ${{ else }}:
     pool:
-      name: Azure-MessagingStore-WinBuildPoolVS2022_0
+      name: ${{ parameters.pool_name }}
       demands:
       - msbuild
       - cmake

--- a/pipeline_templates/build_linux.yml
+++ b/pipeline_templates/build_linux.yml
@@ -5,6 +5,9 @@ parameters:
   - name: ctest_exclude_regex
     type: string
     default: ''
+  - name: pool_name
+    type: string
+    default: 'Azure-MsgStore-Linux2204BuildMachinePool'
 
 jobs:
 - job: linuxubuntu
@@ -13,7 +16,7 @@ jobs:
     Codeql.Enabled: false
     crash_reports_directory: $(Build.ArtifactStagingDirectory)/crash_reports
   pool:
-    name: Azure-MsgStore-Linux2204BuildMachinePool
+    name: ${{ parameters.pool_name }}
     demands:
       - linux
   workspace:

--- a/pipeline_templates/codeql3000_default.yml
+++ b/pipeline_templates/codeql3000_default.yml
@@ -9,12 +9,15 @@ parameters:
   default: 'RelWithDebInfo'
 - name: repo_root
   default: $(Build.SourcesDirectory)/deps/c-build-tools
+- name: pool_name
+  type: string
+  default: 'Azure-MessagingStore-WinBuildPoolVS2022_0'
 
 jobs:
 - job: codeql
   displayName: 'Run CodeQL on production code'
   pool:
-    name: Azure-MessagingStore-WinBuildPoolVS2022_0
+    name: ${{ parameters.pool_name }}
     demands:
     - Cmd
     - msbuild

--- a/pipeline_templates/run_master_check.yml
+++ b/pipeline_templates/run_master_check.yml
@@ -9,12 +9,15 @@ parameters:
   - name: custom_submodule_branches # Comma-separated list of custom submodule branches, in the format "submodulePath:branchName", e.g. "deps/libuv:master,submodule2:develop"
     default: ""
     type: string
+  - name: pool_name
+    type: string
+    default: "Azure-MessagingStore-WinBuildPoolVS2022_0"
 
 jobs:
 - job: run_master_check
   displayName: 'Run submodule master check'
   pool:
-    name: Azure-MessagingStore-WinBuildPoolVS2022_0
+    name: ${{ parameters.pool_name }}
     demands:
     - Cmd
 

--- a/pipeline_templates/run_master_check.yml
+++ b/pipeline_templates/run_master_check.yml
@@ -12,45 +12,49 @@ parameters:
   - name: pool_name
     type: string
     default: "Azure-MessagingStore-WinBuildPoolVS2022_0"
+  - name: skip_master_check
+    type: boolean
+    default: false
 
 jobs:
-- job: run_master_check
-  displayName: 'Run submodule master check'
-  pool:
-    name: ${{ parameters.pool_name }}
-    demands:
-    - Cmd
+- ${{ if not(parameters.skip_master_check) }}:
+  - job: run_master_check
+    displayName: 'Run submodule master check'
+    pool:
+      name: ${{ parameters.pool_name }}
+      demands:
+      - Cmd
 
-  workspace:
-    clean: all
+    workspace:
+      clean: all
 
-  steps:
-  - checkout: self
-    submodules: true
-    clean: false
+    steps:
+    - checkout: self
+      submodules: true
+      clean: false
 
-  - task: BatchScript@1
-    displayName: 'Git submodule update'
-    inputs:
-      filename: 'C:\Program Files\Git\bin\git.exe'
-      arguments: 'submodule update --init --force'
+    - task: BatchScript@1
+      displayName: 'Git submodule update'
+      inputs:
+        filename: 'C:\Program Files\Git\bin\git.exe'
+        arguments: 'submodule update --init --force'
 
-  - task: BatchScript@1
-    displayName: 'Git submodule clean'
-    inputs:
-      filename: 'C:\Program Files\Git\bin\git.exe'
-      arguments: 'submodule foreach --recursive "git clean -xdff"'
+    - task: BatchScript@1
+      displayName: 'Git submodule clean'
+      inputs:
+        filename: 'C:\Program Files\Git\bin\git.exe'
+        arguments: 'submodule foreach --recursive "git clean -xdff"'
 
-  - task: BatchScript@1
-    displayName: 'Git clean'
-    inputs:
-      filename: 'C:\Program Files\Git\bin\git.exe'
-      arguments: 'clean -xdff'
+    - task: BatchScript@1
+      displayName: 'Git clean'
+      inputs:
+        filename: 'C:\Program Files\Git\bin\git.exe'
+        arguments: 'clean -xdff'
 
-  - task: PowerShell@2
-    displayName: 'Verify submodules are ancestors of their master branch'
-    inputs:
-      targetType: 'filePath'
-      filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/submodule_master_check.ps1'
-      arguments: '-ignoreSubmodules "${{ parameters.ignore_submodules }}" -customSubmoduleBranches "${{ parameters.custom_submodule_branches }}"'
-    continueOnError: false
+    - task: PowerShell@2
+      displayName: 'Verify submodules are ancestors of their master branch'
+      inputs:
+        targetType: 'filePath'
+        filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/submodule_master_check.ps1'
+        arguments: '-ignoreSubmodules "${{ parameters.ignore_submodules }}" -customSubmoduleBranches "${{ parameters.custom_submodule_branches }}"'
+      continueOnError: false


### PR DESCRIPTION
## Changes

1. **Parameterize build pool names** (from anporumb_arm64_work branch):
   - Add \pool_name_x64\ and \pool_name_arm64\ parameters to \uild_all_flavors.yml\ and \uild_and_run_tests.yml\
   - Add \pool_name\ parameter to \uild_linux.yml\, \codeql3000_default.yml\, and \un_master_check.yml\
   - Replace hardcoded pool names with parameterized values

2. **Add \skip_master_check\ parameter** to \un_master_check.yml\:
   - New boolean parameter \skip_master_check\ (default: \alse\)
   - When set to \	rue\, the entire master check job is skipped
   - No behavior change for existing consumers (defaults to running the check)