### PR TITLE
Fix vstest.yml failing when failOnMinTestsNotRun is false

### DIFF
--- a/pipeline_templates/tasks/vstest.yml
+++ b/pipeline_templates/tasks/vstest.yml
@@ -93,8 +93,13 @@ steps:
       
       $testAssemblies = Get-ChildItem -Path "$(Build.BinariesDirectory)" -Recurse -Filter "*_ut_*.dll" | Where-Object { $_.FullName -notmatch '\\ref\\' }
       if ($testAssemblies.Count -eq 0) {
-        Write-Error "No test assemblies found matching pattern"
-        exit 1
+        if ('${{ parameters.failOnMinTestsNotRun }}' -eq 'true') {
+          Write-Error "No test assemblies found matching pattern"
+          exit 1
+        } else {
+          Write-Warning "No test assemblies found matching pattern, but failOnMinTestsNotRun is false - skipping"
+          exit 0
+        }
       }
       
       $args = @()


### PR DESCRIPTION
The early check for missing test assemblies was unconditionally exiting with error code 1, ignoring the failOnMinTestsNotRun parameter. Now when failOnMinTestsNotRun is false and no assemblies are found, the script emits a warning and exits successfully.