### PR TITLE
Remove hardcoded v143 toolset from vcpkg triplets and new VLD ignore

### DIFF
--- a/build_functions/default_vld.ini
+++ b/build_functions/default_vld.ini
@@ -94,31 +94,28 @@ SkipCrtStartupLeaks = yes
 ;
 IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahCreateHandleContextTable,WahInsertHandleContext,MesBufferHandleReset,WSALookupServiceBeginW
 
-; Suppress false positives from system DLLs whose internal functions are
-; unexported and cannot be targeted by IgnoreFunctionsList.
+; Suppress false positives from system DLLs loaded during getaddrinfo.
 ;
-; During getaddrinfo, the Winsock layer dynamically loads several namespace
-; provider DLLs. Their DLL initialization allocates memory that persists
-; for the process lifetime and is cleaned up by the OS at process exit.
-; The specific DLLs that leak depend on the OS version and installed
-; network providers:
+; When getaddrinfo is first called, the Winsock layer (WS2_32.dll)
+; enumerates namespace providers via WSAEnumNameSpaceProvidersW. This
+; triggers dynamic loading of provider DLLs whose initialization allocates
+; memory that persists for the process lifetime (freed at process exit).
+;
+; The majority of leak blocks come from RPCRT4.dll (RPC binding setup,
+; buffer allocation, context handles) and KERNELBASE.dll (LoadLibraryExW
+; for provider DLLs). The exact DLLs and block sizes vary by OS version
+; and installed network providers. Common leaking DLLs include:
 ;
 ;   - rasadhlp.dll: Remote Access Service Address Helper. Loaded via
-;     LoadLibraryExA during first getaddrinfo call through
-;     WSAEnumNameSpaceProvidersW -> WSALookupServiceBeginW. Internal
-;     functions at unexported RVA offsets allocate 256-byte blocks.
+;     LoadLibraryExA during namespace provider enumeration.
 ;
-;   - dnsapi.dll: DNS Client API. Internal functions perform locale
-;     comparison (CompareStringW) and DLL initialization that allocate
-;     400-byte blocks via RtlAllocateHeap.
+;   - dnsapi.dll: DNS Client API. Performs resolver initialization.
 ;
 ;   - mswsock.dll: Microsoft Windows Sockets Helper. Winsock provider
-;     DLL that allocates socket handle context entries and performs
-;     provider path resolution during name resolution.
+;     DLL that allocates internal state during name resolution.
 ;
-;   - fwpuclnt.dll: Windows Filtering Platform User-mode API. Network
-;     policy DLL loaded during socket/DNS operations that allocates
-;     internal state.
+;   - fwpuclnt.dll: Windows Filtering Platform User-mode API. May be
+;     loaded during socket/DNS operations on some OS configurations.
 ;
 ; NOTE: IgnoreModulesList requires VLD v2.5.15+ with IgnoreModulesList
 ; support. Older VLD versions will silently ignore this option.

--- a/build_functions/default_vld.ini
+++ b/build_functions/default_vld.ini
@@ -76,17 +76,17 @@ SkipCrtStartupLeaks = yes
 ;     the public MesEncodeDynBufferHandleCreate because the latter could
 ;     mask real leaks from intentional RPC serialization usage.
 ;
-;   - getaddrinfo: public WS2_32.dll DNS resolution function.
-;     During the first call to getaddrinfo, the Winsock layer dynamically
-;     loads rasadhlp.dll (Remote Access Service Address Helper) via
-;     LoadLibraryExA to enumerate namespace providers. The rasadhlp.dll
-;     initialization allocates 256-byte blocks (via malloc) that persist
-;     for the process lifetime and are cleaned up at process exit by the
-;     OS. Unlike the WAH entries above, these allocations originate from
-;     rasadhlp.dll internal code (not from WS2_32.dll internals), so the
-;     internal function names are not available as stable suppression
-;     targets. Suppressing getaddrinfo is acceptable here because the
-;     leaked blocks are strictly from the one-time provider enumeration
-;     path, not from application-level DNS usage.
+;   - WSALookupServiceBeginW: WS2_32.dll namespace provider lookup function.
+;     During DNS resolution, getaddrinfo -> GetAddrInfoW calls
+;     WSAEnumNameSpaceProvidersW, which internally calls
+;     WSALookupServiceBeginW to enumerate providers. On the first call,
+;     this triggers LoadLibraryExA to load rasadhlp.dll (Remote Access
+;     Service Address Helper), whose DLL initialization allocates 256-byte
+;     blocks (via malloc) that persist for the process lifetime. The
+;     rasadhlp.dll internal functions are unexported and unresolvable
+;     without PDBs, so we suppress at this level instead. Using
+;     WSALookupServiceBeginW rather than the public getaddrinfo avoids
+;     masking real leaks where application code calls getaddrinfo without
+;     a matching freeaddrinfo.
 ;
-IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahCreateHandleContextTable,WahInsertHandleContext,MesBufferHandleReset,getaddrinfo
+IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahCreateHandleContextTable,WahInsertHandleContext,MesBufferHandleReset,WSALookupServiceBeginW

--- a/build_functions/default_vld.ini
+++ b/build_functions/default_vld.ini
@@ -49,4 +49,25 @@ SkipCrtStartupLeaks = yes
 ;   - UuidFromStringA, UuidToStringA: RPCRT4.dll caches computer name via GetComputerNameExW
 ;   - SymLoadModuleExW, SymGetLineFromAddr64, SymFromAddr, GetSymLoadError: dbghelp.dll symbol caches
 ;   - SortGetHandle, InternalLcidToName, GetNamedLocaleHashNode: kernel locale caches
-IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode
+;
+;   Winsock / DNS false positives (observed on VS 2025 / Windows Server 2025):
+;
+;   - WahInsertHandleContext: undocumented WS2_32.dll internal function.
+;     Inserts per-socket entries (256-byte blocks) into the Winsock helper
+;     (WAH) handle context hash table. These are process-lifetime allocations
+;     that the OS cleans up at process exit. They appear in every call stack
+;     that creates a socket (socket, WSASocketW, accept) or resolves DNS
+;     (getaddrinfo -> DNSAPI -> mswsock). Using this internal name rather
+;     than the public callers (WSASocketW, accept, getaddrinfo) avoids
+;     accidentally suppressing real application leaks in code that uses
+;     those public APIs.
+;
+;   - MesBufferHandleReset: undocumented RPCRT4.dll internal function.
+;     Called during DNS name resolution to cache the local computer name
+;     via GetComputerNameExW -> MesEncodeDynBufferHandleCreate. This is a
+;     one-time 32-byte RPC serialization buffer allocation that persists
+;     for the process lifetime. Using this internal name is preferred over
+;     the public MesEncodeDynBufferHandleCreate because the latter could
+;     mask real leaks from intentional RPC serialization usage.
+;
+IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahInsertHandleContext,MesBufferHandleReset

--- a/build_functions/default_vld.ini
+++ b/build_functions/default_vld.ini
@@ -88,5 +88,39 @@ SkipCrtStartupLeaks = yes
 ;     WSALookupServiceBeginW rather than the public getaddrinfo avoids
 ;     masking real leaks where application code calls getaddrinfo without
 ;     a matching freeaddrinfo.
+;     NOTE: This is also covered by IgnoreModulesList below (rasadhlp.dll).
+;     WSALookupServiceBeginW is kept here as a fallback for older VLD
+;     versions that do not support IgnoreModulesList.
 ;
 IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahCreateHandleContextTable,WahInsertHandleContext,MesBufferHandleReset,WSALookupServiceBeginW
+
+; Suppress false positives from system DLLs whose internal functions are
+; unexported and cannot be targeted by IgnoreFunctionsList.
+;
+; During getaddrinfo, the Winsock layer dynamically loads several namespace
+; provider DLLs. Their DLL initialization allocates memory that persists
+; for the process lifetime and is cleaned up by the OS at process exit.
+; The specific DLLs that leak depend on the OS version and installed
+; network providers:
+;
+;   - rasadhlp.dll: Remote Access Service Address Helper. Loaded via
+;     LoadLibraryExA during first getaddrinfo call through
+;     WSAEnumNameSpaceProvidersW -> WSALookupServiceBeginW. Internal
+;     functions at unexported RVA offsets allocate 256-byte blocks.
+;
+;   - dnsapi.dll: DNS Client API. Internal functions perform locale
+;     comparison (CompareStringW) and DLL initialization that allocate
+;     400-byte blocks via RtlAllocateHeap.
+;
+;   - mswsock.dll: Microsoft Windows Sockets Helper. Winsock provider
+;     DLL that allocates socket handle context entries and performs
+;     provider path resolution during name resolution.
+;
+;   - fwpuclnt.dll: Windows Filtering Platform User-mode API. Network
+;     policy DLL loaded during socket/DNS operations that allocates
+;     internal state.
+;
+; NOTE: IgnoreModulesList requires VLD v2.5.15+ with IgnoreModulesList
+; support. Older VLD versions will silently ignore this option.
+;
+IgnoreModulesList = rasadhlp.dll;dnsapi.dll;mswsock.dll;fwpuclnt.dll

--- a/build_functions/default_vld.ini
+++ b/build_functions/default_vld.ini
@@ -47,6 +47,8 @@ SkipCrtStartupLeaks = yes
 ;     CryptEnumOIDFunction, CertOIDToAlgId, CryptMsgSignCTL,
 ;     CryptMsgOpenToDecode: CRYPT32.dll OID/ASN1 caches
 ;   - UuidFromStringA, UuidToStringA: RPCRT4.dll caches computer name via GetComputerNameExW
+;   - MesBufferHandleReset: RPCRT4.dll caches computer name during DNS resolution
 ;   - SymLoadModuleExW, SymGetLineFromAddr64, SymFromAddr, GetSymLoadError: dbghelp.dll symbol caches
 ;   - SortGetHandle, InternalLcidToName, GetNamedLocaleHashNode: kernel locale caches
-IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode
+;   - WahInsertHandleContext: WS2_32.dll Winsock handle context hash table entries
+IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,MesBufferHandleReset,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahInsertHandleContext

--- a/build_functions/default_vld.ini
+++ b/build_functions/default_vld.ini
@@ -47,8 +47,6 @@ SkipCrtStartupLeaks = yes
 ;     CryptEnumOIDFunction, CertOIDToAlgId, CryptMsgSignCTL,
 ;     CryptMsgOpenToDecode: CRYPT32.dll OID/ASN1 caches
 ;   - UuidFromStringA, UuidToStringA: RPCRT4.dll caches computer name via GetComputerNameExW
-;   - MesBufferHandleReset: RPCRT4.dll caches computer name during DNS resolution
 ;   - SymLoadModuleExW, SymGetLineFromAddr64, SymFromAddr, GetSymLoadError: dbghelp.dll symbol caches
 ;   - SortGetHandle, InternalLcidToName, GetNamedLocaleHashNode: kernel locale caches
-;   - WahInsertHandleContext: WS2_32.dll Winsock handle context hash table entries
-IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,MesBufferHandleReset,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahInsertHandleContext
+IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode

--- a/build_functions/default_vld.ini
+++ b/build_functions/default_vld.ini
@@ -76,4 +76,17 @@ SkipCrtStartupLeaks = yes
 ;     the public MesEncodeDynBufferHandleCreate because the latter could
 ;     mask real leaks from intentional RPC serialization usage.
 ;
-IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahCreateHandleContextTable,WahInsertHandleContext,MesBufferHandleReset
+;   - getaddrinfo: public WS2_32.dll DNS resolution function.
+;     During the first call to getaddrinfo, the Winsock layer dynamically
+;     loads rasadhlp.dll (Remote Access Service Address Helper) via
+;     LoadLibraryExA to enumerate namespace providers. The rasadhlp.dll
+;     initialization allocates 256-byte blocks (via malloc) that persist
+;     for the process lifetime and are cleaned up at process exit by the
+;     OS. Unlike the WAH entries above, these allocations originate from
+;     rasadhlp.dll internal code (not from WS2_32.dll internals), so the
+;     internal function names are not available as stable suppression
+;     targets. Suppressing getaddrinfo is acceptable here because the
+;     leaked blocks are strictly from the one-time provider enumeration
+;     path, not from application-level DNS usage.
+;
+IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahCreateHandleContextTable,WahInsertHandleContext,MesBufferHandleReset,getaddrinfo

--- a/build_functions/default_vld.ini
+++ b/build_functions/default_vld.ini
@@ -109,15 +109,7 @@ IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encod
 ;   - rasadhlp.dll: Remote Access Service Address Helper. Loaded via
 ;     LoadLibraryExA during namespace provider enumeration.
 ;
-;   - dnsapi.dll: DNS Client API. Performs resolver initialization.
-;
-;   - mswsock.dll: Microsoft Windows Sockets Helper. Winsock provider
-;     DLL that allocates internal state during name resolution.
-;
-;   - fwpuclnt.dll: Windows Filtering Platform User-mode API. May be
-;     loaded during socket/DNS operations on some OS configurations.
-;
 ; NOTE: IgnoreModulesList requires VLD v2.5.15+ with IgnoreModulesList
 ; support. Older VLD versions will silently ignore this option.
 ;
-IgnoreModulesList = rasadhlp.dll;dnsapi.dll;mswsock.dll;fwpuclnt.dll
+IgnoreModulesList = rasadhlp.dll

--- a/build_functions/default_vld.ini
+++ b/build_functions/default_vld.ini
@@ -52,15 +52,21 @@ SkipCrtStartupLeaks = yes
 ;
 ;   Winsock / DNS false positives (observed on VS 2025 / Windows Server 2025):
 ;
-;   - WahInsertHandleContext: undocumented WS2_32.dll internal function.
-;     Inserts per-socket entries (256-byte blocks) into the Winsock helper
-;     (WAH) handle context hash table. These are process-lifetime allocations
-;     that the OS cleans up at process exit. They appear in every call stack
-;     that creates a socket (socket, WSASocketW, accept) or resolves DNS
-;     (getaddrinfo -> DNSAPI -> mswsock). Using this internal name rather
-;     than the public callers (WSASocketW, accept, getaddrinfo) avoids
+;   - WahCreateHandleContextTable: undocumented WS2_32.dll internal function.
+;     Creates the Winsock helper (WAH) handle context hash table (2312-byte
+;     blocks allocated via GlobalAlloc). Called by WSAStartup to initialize
+;     the process-wide table, and again via WSASocketW/socket/mswsock for
+;     provider-specific tables. These are process-lifetime allocations that
+;     the OS cleans up at process exit. Using this internal name rather
+;     than the public callers (WSAStartup, WSASocketW, socket) avoids
 ;     accidentally suppressing real application leaks in code that uses
 ;     those public APIs.
+;
+;   - WahInsertHandleContext: undocumented WS2_32.dll internal function.
+;     Inserts per-socket entries (256-byte blocks) into the WAH handle
+;     context hash table created by WahCreateHandleContextTable. These
+;     appear in call stacks that create sockets or resolve DNS. Using this
+;     internal name avoids suppressing real leaks from public socket APIs.
 ;
 ;   - MesBufferHandleReset: undocumented RPCRT4.dll internal function.
 ;     Called during DNS name resolution to cache the local computer name
@@ -70,4 +76,4 @@ SkipCrtStartupLeaks = yes
 ;     the public MesEncodeDynBufferHandleCreate because the latter could
 ;     mask real leaks from intentional RPC serialization usage.
 ;
-IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahInsertHandleContext,MesBufferHandleReset
+IgnoreFunctionsList = CryptFindOIDInfo,I_CryptGetAsn1Decoder,I_CryptGetAsn1Encoder,CryptEnumOIDFunction,CertOIDToAlgId,CryptMsgSignCTL,CryptMsgOpenToDecode,UuidFromStringA,UuidToStringA,SymLoadModuleExW,SymGetLineFromAddr64,SymFromAddr,GetSymLoadError,SortGetHandle,InternalLcidToName,GetNamedLocaleHashNode,WahCreateHandleContextTable,WahInsertHandleContext,MesBufferHandleReset

--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -251,10 +251,10 @@ jobs:
         repo_root: ${{ parameters.repo_root_override }}
 
   - task: PublishPipelineArtifact@1
-    displayName: 'Publish ${{ parameters.ARCH_TYPE }} ${{ parameters.build_configuration}} Artifacts'
+    displayName: 'Publish ${{ parameters.ARCH_TYPE }} ${{ parameters.build_configuration}} ${{ parameters.GBALLOC_LL_TYPE }} Artifacts'
     inputs:
       targetPath: $(Build.BinariesDirectory)
-      artifactName: ${{ parameters.build_configuration}}_${{ parameters.ARCH_TYPE }}_artifacts
+      artifactName: ${{ parameters.build_configuration}}_${{ parameters.GBALLOC_LL_TYPE }}_${{ parameters.ARCH_TYPE }}_artifacts
       parallel: true
     condition: failed()
 

--- a/vcpkg_triplets/arm64-windows-static-cbt-asan.cmake
+++ b/vcpkg_triplets/arm64-windows-static-cbt-asan.cmake
@@ -1,7 +1,7 @@
 set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_PLATFORM_TOOLSET v143)
+# VCPKG_PLATFORM_TOOLSET not set - auto-detect from the current VS installation
 # Unfortunately we have to workaround an issue introduced in Visual Studio 17.10 where due to a change in mutex a break in the ABI seems to exist
 # https://github.com/microsoft/STL/releases/tag/vs-2022-17.10
 # Fixed mutex's constructor to be constexpr. #3824 #4000 #4339

--- a/vcpkg_triplets/x64-windows-static-cbt-asan.cmake
+++ b/vcpkg_triplets/x64-windows-static-cbt-asan.cmake
@@ -1,7 +1,7 @@
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_PLATFORM_TOOLSET v143)
+# VCPKG_PLATFORM_TOOLSET not set - auto-detect from the current VS installation
 # Unfortunately we have to workaround an issue introduced in Visual Studio 17.10 where due to a change in mutex a break in the ABI seems to exist
 # https://github.com/microsoft/STL/releases/tag/vs-2022-17.10
 # Fixed mutex's constructor to be constexpr. #3824 #4000 #4339

--- a/vcpkg_triplets/x64-windows-static-cbt.cmake
+++ b/vcpkg_triplets/x64-windows-static-cbt.cmake
@@ -1,7 +1,7 @@
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_PLATFORM_TOOLSET v143)
+# VCPKG_PLATFORM_TOOLSET not set - auto-detect from the current VS installation
 # Unfortunately we have to workaround an issue introduced in Visual Studio 17.10 where due to a change in mutex a break in the ABI seems to exist
 # https://github.com/microsoft/STL/releases/tag/vs-2022-17.10
 # Fixed mutex's constructor to be constexpr. #3824 #4000 #4339

--- a/vcpkg_triplets/x86-windows-static-cbt-asan.cmake
+++ b/vcpkg_triplets/x86-windows-static-cbt-asan.cmake
@@ -1,7 +1,7 @@
 set(VCPKG_TARGET_ARCHITECTURE x86)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_PLATFORM_TOOLSET v143)
+# VCPKG_PLATFORM_TOOLSET not set - auto-detect from the current VS installation
 # Unfortunately we have to workaround an issue introduced in Visual Studio 17.10 where due to a change in mutex a break in the ABI seems to exist
 # https://github.com/microsoft/STL/releases/tag/vs-2022-17.10
 # Fixed mutex's constructor to be constexpr. #3824 #4000 #4339

--- a/vcpkg_triplets/x86-windows-static-cbt.cmake
+++ b/vcpkg_triplets/x86-windows-static-cbt.cmake
@@ -1,7 +1,7 @@
 set(VCPKG_TARGET_ARCHITECTURE x86)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_PLATFORM_TOOLSET v143)
+# VCPKG_PLATFORM_TOOLSET not set - auto-detect from the current VS installation
 # Unfortunately we have to workaround an issue introduced in Visual Studio 17.10 where due to a change in mutex a break in the ABI seems to exist
 # https://github.com/microsoft/STL/releases/tag/vs-2022-17.10
 # Fixed mutex's constructor to be constexpr. #3824 #4000 #4339


### PR DESCRIPTION
All triplets now auto-detect the platform toolset from the current VS installation instead of requiring v143 specifically. This matches the pattern already used by arm64-windows-static-cbt.cmake and allows builds to work on both VS 2022 (v143) and VS 2025 (v145).

Also fixes arm64-windows-static-cbt-asan.cmake which inconsistently hardcoded v143 while its non-asan counterpart did not.