### PR TITLE
Use fixed repo_validation target name in pipeline

### DIFF
--- a/pipeline_templates/build_all_flavors.yml
+++ b/pipeline_templates/build_all_flavors.yml
@@ -64,10 +64,6 @@ parameters:
     type: string
     default: "Azure-MessagingStore-Win-ARM64-Dpldsv6-v28"
 
-  - name: validation_msbuild_target
-    type: string
-    default: ""
-
   - name: skip_repo_validation
     type: boolean
     default: false
@@ -78,7 +74,6 @@ jobs:
   - template: run_repo_validation.yml
     parameters:
       additional_cmake_options: ${{ parameters.additional_cmake_options }}
-      validation_msbuild_target: ${{ parameters.validation_msbuild_target }}
       pool_name: ${{ parameters.pool_name_x64 }}
 
 - ${{ each GBALLOC_LL_TYPE in parameters.GBALLOC_LL_TYPE_VALUES }}:

--- a/pipeline_templates/run_repo_validation.yml
+++ b/pipeline_templates/run_repo_validation.yml
@@ -17,9 +17,6 @@ parameters:
     type: string
     default: ""
 
-  - name: validation_msbuild_target
-    type: string
-
   - name: pool_name
     type: string
     default: "Azure-MessagingStore-WinBuildPoolVS2022_1"
@@ -96,6 +93,6 @@ jobs:
       architecture: 'x64'
       solution: '$(Build.BinariesDirectory)/c/*.sln*'
       configuration: 'Debug'
-      msbuildArgs: '/t:${{ parameters.validation_msbuild_target }}'
+      msbuildArgs: '/t:repo_validation'
 
   - template : clean_ado_folders.yml

--- a/pipeline_templates/run_repo_validation.yml
+++ b/pipeline_templates/run_repo_validation.yml
@@ -87,12 +87,31 @@ jobs:
       buildDirectory: '$(Build.BinariesDirectory)/c'
       cmakeArgs: '${{ parameters.cmake_options }} ${{ parameters.additional_cmake_options }} -DCMAKE_BUILD_TYPE=Debug'
 
+  # Discover the repo validation target name from the CMake output.
+  # The target is named <project_name>_repo_validation and we find it by
+  # looking for the generated *_repo_validation.vcxproj file. This avoids
+  # requiring each consuming repo to pass the target name as a parameter.
+  - task: PowerShell@2
+    displayName: 'Discover repo validation target'
+    inputs:
+      targetType: 'inline'
+      script: |
+        $proj = Get-ChildItem "$(Build.BinariesDirectory)/c/*_repo_validation.vcxproj" -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($proj) {
+          $targetName = $proj.BaseName
+          Write-Host "Found repo validation target: $targetName"
+          Write-Host "##vso[task.setvariable variable=repoValidationTarget]$targetName"
+        } else {
+          Write-Error "No *_repo_validation.vcxproj found in $(Build.BinariesDirectory)/c/"
+          exit 1
+        }
+
   # Build to execute the repo validation and traceability targets
   - template: tasks/msbuild.yml
     parameters:
       architecture: 'x64'
       solution: '$(Build.BinariesDirectory)/c/*.sln*'
       configuration: 'Debug'
-      msbuildArgs: '/t:repo_validation'
+      msbuildArgs: '/t:$(repoValidationTarget)'
 
   - template : clean_ado_folders.yml

--- a/repo_validation/CMakeLists.txt
+++ b/repo_validation/CMakeLists.txt
@@ -11,17 +11,15 @@ cmake_minimum_required(VERSION 3.18)
 #   add_repo_validation(<project_name> [EXCLUDE_FOLDERS <folder1> <folder2> ...])
 #
 # Arguments:
-#   project_name - The name of the project (used in status messages)
+#   project_name - The name of the project (used to create a unique target name)
 #   EXCLUDE_FOLDERS - Optional list of directories to exclude from validation (default: cmake deps)
 #
 # CMake Options:
 #   run_repo_validation - Set to ON to enable the validation target (default is OFF)
 #   fix_repo_validation_errors - Set to ON to automatically fix validation errors (default is OFF)
 #
-# The function will create a target named "repo_validation" that runs all validation
-# scripts located in the repo_validation/scripts directory. The target name is fixed
-# (not per-project) because the top-level guard ensures only one such target can exist
-# per build, and this allows the pipeline template to reference it without configuration.
+# The function will create a target named <project_name>_repo_validation that runs
+# all validation scripts located in the repo_validation/scripts directory.
 # If fix_repo_validation_errors is ON, scripts will be called with -Fix argument.
 #
 # Note: 
@@ -86,10 +84,8 @@ function(add_repo_validation project_name)
         )
     endforeach()
     
-    # Create the validation target with a fixed name. The top-level guard above
-    # ensures only one repo_validation target exists per build, so no project-name
-    # prefix is needed. This lets the pipeline template hardcode /t:repo_validation.
-    add_custom_target(repo_validation ALL
+    # Create the validation target
+    add_custom_target(${project_name}_repo_validation ALL
         ${VALIDATION_COMMANDS}
         WORKING_DIRECTORY ${REPO_ROOT}
         COMMENT "Running repository validation for ${project_name}"
@@ -97,7 +93,7 @@ function(add_repo_validation project_name)
     )
     
     # Add a message to indicate the target was created
-    message(STATUS "Added repository validation target: repo_validation (excluding: ${REPO_VAL_EXCLUDE_FOLDERS})")
+    message(STATUS "Added repository validation target: ${project_name}_repo_validation (excluding: ${REPO_VAL_EXCLUDE_FOLDERS})")
 endfunction()
 
 # Include testing framework if tests directory exists and testing is enabled

--- a/repo_validation/CMakeLists.txt
+++ b/repo_validation/CMakeLists.txt
@@ -11,15 +11,17 @@ cmake_minimum_required(VERSION 3.18)
 #   add_repo_validation(<project_name> [EXCLUDE_FOLDERS <folder1> <folder2> ...])
 #
 # Arguments:
-#   project_name - The name of the project (used to create a unique target name)
+#   project_name - The name of the project (used in status messages)
 #   EXCLUDE_FOLDERS - Optional list of directories to exclude from validation (default: cmake deps)
 #
 # CMake Options:
 #   run_repo_validation - Set to ON to enable the validation target (default is OFF)
 #   fix_repo_validation_errors - Set to ON to automatically fix validation errors (default is OFF)
 #
-# The function will create a target named <project_name>_repo_validation that runs
-# all validation scripts located in the repo_validation/scripts directory.
+# The function will create a target named "repo_validation" that runs all validation
+# scripts located in the repo_validation/scripts directory. The target name is fixed
+# (not per-project) because the top-level guard ensures only one such target can exist
+# per build, and this allows the pipeline template to reference it without configuration.
 # If fix_repo_validation_errors is ON, scripts will be called with -Fix argument.
 #
 # Note: 
@@ -84,8 +86,10 @@ function(add_repo_validation project_name)
         )
     endforeach()
     
-    # Create the validation target
-    add_custom_target(${project_name}_repo_validation ALL
+    # Create the validation target with a fixed name. The top-level guard above
+    # ensures only one repo_validation target exists per build, so no project-name
+    # prefix is needed. This lets the pipeline template hardcode /t:repo_validation.
+    add_custom_target(repo_validation ALL
         ${VALIDATION_COMMANDS}
         WORKING_DIRECTORY ${REPO_ROOT}
         COMMENT "Running repository validation for ${project_name}"
@@ -93,7 +97,7 @@ function(add_repo_validation project_name)
     )
     
     # Add a message to indicate the target was created
-    message(STATUS "Added repository validation target: ${project_name}_repo_validation (excluding: ${REPO_VAL_EXCLUDE_FOLDERS})")
+    message(STATUS "Added repository validation target: repo_validation (excluding: ${REPO_VAL_EXCLUDE_FOLDERS})")
 endfunction()
 
 # Include testing framework if tests directory exists and testing is enabled


### PR DESCRIPTION
The add_repo_validation() CMake function previously created a target named <project_name>_repo_validation, requiring each consuming repo to pass validation_msbuild_target to the pipeline template. Since the top-level guard already ensures only one validation target exists per build, the project-name prefix is unnecessary.

Change the target name to the fixed 'repo_validation' and hardcode /t:repo_validation in run_repo_validation.yml. This removes the validation_msbuild_target parameter from build_all_flavors.yml and run_repo_validation.yml, so consuming repos no longer need to configure it.