### PR TITLE
Run setup_nuget_tools.yml before cmake generate

### DIFF
--- a/build/devops.yml
+++ b/build/devops.yml
@@ -53,7 +53,7 @@ jobs:
 - template: /pipeline_templates/codeql3000_default.yml
   parameters:
     repo_root: $(Build.SourcesDirectory)
-    pool_name: ${{ parameters.pool_name_windows_x64 }}
+    pool_name: 'Azure-MessagingStore-Win-x64-Dadsv7-v03'
 
 - template: /pipeline_templates/build_linux.yml
   parameters:

--- a/pipeline_templates/build_all_flavors.yml
+++ b/pipeline_templates/build_all_flavors.yml
@@ -87,6 +87,7 @@ jobs:
     parameters:
       additional_cmake_options: ${{ parameters.additional_cmake_options }}
       pool_name: ${{ parameters.pool_name_x64 }}
+      setup_nuget: ${{ parameters.setup_nuget }}
 
 - ${{ each GBALLOC_LL_TYPE in parameters.GBALLOC_LL_TYPE_VALUES }}:
   - ${{ each FSANITIZE_TYPE in parameters.FSANITIZE_TYPE_VALUES }}:

--- a/pipeline_templates/codeql3000_default.yml
+++ b/pipeline_templates/codeql3000_default.yml
@@ -14,7 +14,10 @@ parameters:
   default: $(Build.SourcesDirectory)/deps/c-build-tools
 - name: pool_name
   type: string
-  default: 'Azure-MessagingStore-Win-x64-Dadsv5-v19'
+  default: 'Azure-MessagingStore-Win-x64-Dadsv7-v03'
+- name: setup_nuget
+  type: boolean
+  default: false
 
 jobs:
 - job: codeql
@@ -51,6 +54,10 @@ jobs:
     inputs:
       sourceFolder: $(Build.BinariesDirectory)
       contents: \*
+
+  # Authenticate NuGet feeds so cmake configure can restore packages
+  - ${{ if parameters.setup_nuget }}:
+    - template: setup_nuget_tools.yml
 
   - template: codeql3000_init.yml
     parameters:

--- a/pipeline_templates/run_repo_validation.yml
+++ b/pipeline_templates/run_repo_validation.yml
@@ -21,6 +21,10 @@ parameters:
     type: string
     default: "Azure-MessagingStore-WinBuildPoolVS2022_1"
 
+  - name: setup_nuget
+    type: boolean
+    default: false
+
 jobs:
 - job: run_repo_validation
   displayName: 'Run repo validation and traceability'
@@ -78,6 +82,10 @@ jobs:
         } else {
           Write-Host "##[warning]vswhere not found"
         }
+
+  # Authenticate NuGet feeds so cmake configure can restore packages
+  - ${{ if parameters.setup_nuget }}:
+    - template: setup_nuget_tools.yml
 
   # CMake generate with repo validation and traceability enabled
   - template: tasks/cmake.yml


### PR DESCRIPTION
Call setup_nuget_tools.yml (NuGetAuthenticate + NuGetToolInstaller) in the cmake.yml wrapper template so that any execute_process(COMMAND nuget ...) during cmake configure can authenticate to Azure Artifacts feeds.