### PR TITLE
Fix C# test file detection for .NET-style naming conventions

### DIFF
--- a/repo_validation/src_rust/src/checks/srs_consistency.rs
+++ b/repo_validation/src_rust/src/checks/srs_consistency.rs
@@ -669,19 +669,30 @@ fn normalize_c_text(text: &str) -> String {
     parts.join(" ")
 }
 
-/// Determine if a file is a test file based on parent directory name ending with _ut or _int,
-/// or for C# files, if the filename starts with "Test" (e.g., TestMyAdapter.cs).
+/// Determine if a file is a test file based on:
+/// - C convention: parent directory name ending with _ut or _int
+/// - C# convention: parent directory ending with UnitTests, IntTests, .UnitTests,
+///   or .IntTests (e.g., MyProject.UnitTests\SomeTests.cs)
+/// - C# convention: filename starting with "Test" (e.g., TestMyAdapter.cs)
+///   or ending with "Tests.cs" (e.g., AllocateAsyncOperationTests.cs)
 fn is_test_file(relative_path: &str) -> bool {
     let parts: Vec<&str> = relative_path.split(['/', '\\']).collect();
     // Check all directory components (not the filename)
     for dir in parts.iter().take(parts.len().saturating_sub(1)) {
+        // C convention: directory ends with _ut or _int
         if dir.ends_with("_ut") || dir.ends_with("_int") {
             return true;
         }
+        // C# convention: directory ends with UnitTests or IntTests
+        if dir.ends_with("UnitTests") || dir.ends_with("IntTests") {
+            return true;
+        }
     }
-    // C# convention: test files start with "Test"
+    // C# convention: filename starts with "Test" or ends with "Tests.cs"
     if let Some(filename) = parts.last() {
-        if filename.ends_with(".cs") && filename.starts_with("Test") {
+        if filename.ends_with(".cs")
+            && (filename.starts_with("Test") || filename.ends_with("Tests.cs"))
+        {
             return true;
         }
     }

--- a/repo_validation/tests/validate_srs_consistency/CMakeLists.txt
+++ b/repo_validation/tests/validate_srs_consistency/CMakeLists.txt
@@ -258,6 +258,14 @@ add_custom_target(test_validate_srs_consistency_cs_inconsistent
     DEPENDS repo_validator_rs
 )
 
+# Test 21: C# .NET-style naming (*.UnitTests, *.IntTests dirs, *Tests.cs filenames)
+add_custom_target(test_validate_srs_consistency_cs_clean_dotnet_naming
+    COMMAND "${REPO_VALIDATOR_RS_EXE}" --repo-root "${CMAKE_CURRENT_SOURCE_DIR}/cs_clean_dotnet_naming" --check srs_consistency
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Testing SRS consistency with .NET-style test naming conventions"
+    DEPENDS repo_validator_rs
+)
+
 # Master target for all SRS consistency validation tests
 add_custom_target(test_validate_srs_consistency
     COMMENT "Running all SRS consistency validation tests"
@@ -282,6 +290,7 @@ add_dependencies(test_validate_srs_consistency
     test_validate_srs_consistency_tag_placement_single_violation
     test_validate_srs_consistency_tag_placement_test_helper
     test_validate_srs_consistency_cs_clean
+    test_validate_srs_consistency_cs_clean_dotnet_naming
 )
 # Master target for all expected-failure tests
 add_custom_target(test_validate_srs_consistency_failures

--- a/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/MyProject.IntTests/DotnetModuleIntTests.cs
+++ b/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/MyProject.IntTests/DotnetModuleIntTests.cs
@@ -1,0 +1,15 @@
+// Integration test C# file in .IntTests directory with *Tests.cs naming
+using System;
+
+namespace MyProject.IntTests
+{
+    public class DotnetModuleIntTests
+    {
+        // Tests_SRS_DOTNET_MODULE_88_003: [ DotnetModule.Dispose shall release all resources. ]
+        public void WhenDisposedThenResourcesAreReleased()
+        {
+            var module = DotnetModule.Create("test");
+            module.Dispose();
+        }
+    }
+}

--- a/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/MyProject.IntTests/DotnetModuleIntTests.cs
+++ b/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/MyProject.IntTests/DotnetModuleIntTests.cs
@@ -8,8 +8,13 @@ namespace MyProject.IntTests
         // Tests_SRS_DOTNET_MODULE_88_003: [ DotnetModule.Dispose shall release all resources. ]
         public void WhenDisposedThenResourcesAreReleased()
         {
+            // arrange
             var module = DotnetModule.Create("test");
+
+            // act
             module.Dispose();
+
+            // assert
         }
     }
 }

--- a/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/MyProject.UnitTests/DotnetModuleTests.cs
+++ b/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/MyProject.UnitTests/DotnetModuleTests.cs
@@ -1,0 +1,22 @@
+// Test C# file in .UnitTests directory with *Tests.cs naming
+// Both the directory name and the filename should identify this as a test file
+using System;
+
+namespace MyProject.UnitTests
+{
+    public class DotnetModuleTests
+    {
+        // Tests_SRS_DOTNET_MODULE_88_001: [ DotnetModule.Create shall validate the input parameters. ]
+        public void WhenNameIsNullThenCreateThrows()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => DotnetModule.Create(null));
+        }
+
+        // Tests_SRS_DOTNET_MODULE_88_002: [ DotnetModule.Create shall allocate resources. ]
+        public void WhenAllOkThenCreateSucceeds()
+        {
+            var module = DotnetModule.Create("test");
+            Assert.IsNotNull(module);
+        }
+    }
+}

--- a/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/MyProject.UnitTests/DotnetModuleTests.cs
+++ b/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/MyProject.UnitTests/DotnetModuleTests.cs
@@ -9,13 +9,24 @@ namespace MyProject.UnitTests
         // Tests_SRS_DOTNET_MODULE_88_001: [ DotnetModule.Create shall validate the input parameters. ]
         public void WhenNameIsNullThenCreateThrows()
         {
-            Assert.ThrowsException<ArgumentNullException>(() => DotnetModule.Create(null));
+            // arrange
+            string name = null;
+
+            // act
+            // assert
+            Assert.ThrowsException<ArgumentNullException>(() => DotnetModule.Create(name));
         }
 
         // Tests_SRS_DOTNET_MODULE_88_002: [ DotnetModule.Create shall allocate resources. ]
         public void WhenAllOkThenCreateSucceeds()
         {
-            var module = DotnetModule.Create("test");
+            // arrange
+            string name = "test";
+
+            // act
+            var module = DotnetModule.Create(name);
+
+            // assert
             Assert.IsNotNull(module);
         }
     }

--- a/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/devdoc/dotnet_module_requirements.md
+++ b/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/devdoc/dotnet_module_requirements.md
@@ -1,0 +1,13 @@
+# dotnet_module requirements
+
+## Overview
+
+Module for testing .NET-style test file detection.
+
+## Requirements
+
+**SRS_DOTNET_MODULE_88_001:** [** DotnetModule.Create shall validate the input parameters. **]**
+
+**SRS_DOTNET_MODULE_88_002:** [** DotnetModule.Create shall allocate resources. **]**
+
+**SRS_DOTNET_MODULE_88_003:** [** DotnetModule.Dispose shall release all resources. **]**

--- a/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/src/DotnetModule.cs
+++ b/repo_validation/tests/validate_srs_consistency/cs_clean_dotnet_naming/src/DotnetModule.cs
@@ -1,0 +1,25 @@
+// Production C# file with Codes_SRS_ tags
+using System;
+
+namespace MyProject
+{
+    public class DotnetModule
+    {
+        // Codes_SRS_DOTNET_MODULE_88_001: [ DotnetModule.Create shall validate the input parameters. ]
+        public static DotnetModule Create(string name)
+        {
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            return new DotnetModule();
+        }
+
+        // Codes_SRS_DOTNET_MODULE_88_002: [ DotnetModule.Create shall allocate resources. ]
+        private DotnetModule()
+        {
+        }
+
+        // Codes_SRS_DOTNET_MODULE_88_003: [ DotnetModule.Dispose shall release all resources. ]
+        public void Dispose()
+        {
+        }
+    }
+}


### PR DESCRIPTION
The is_test_file() function only recognized C-style test directories (ending with _ut or _int) and C# files starting with 'Test'. This caused 708 false positives in EBS where test files use .NET conventions:
- Directories: *.UnitTests, *.IntTests
- Filenames: *Tests.cs

Now also matches directory names ending with UnitTests or IntTests and filenames ending with Tests.cs.

Added test fixture cs_clean_dotnet_naming to cover the new patterns.