### PR TITLE
[MrBot] Fix update_deps scripts for PowerShell 5.1 compatibility

### DIFF
--- a/update_deps/helper_scripts/git_operations.ps1
+++ b/update_deps/helper_scripts/git_operations.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft. All rights reserved.
+﻿# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 # Git operations functions for propagate_updates.ps1
@@ -531,7 +531,8 @@ function collect-upstream-changes
                             {
                                 foreach ($upstream_change in $global:repo_change_descriptions[$sub_repo_name])
                                 {
-                                    if (-not $seen_shas.ContainsKey($upstream_change.SHA))
+                                    if ($upstream_change.SHA -and
+                                        -not $seen_shas.ContainsKey($upstream_change.SHA))
                                     {
                                         $seen_shas[$upstream_change.SHA] = $true
                                         $changes += $upstream_change
@@ -706,7 +707,7 @@ function update-local-repo
     {
         $global:repo_change_descriptions = @{}
     }
-    $global:repo_change_descriptions[$repo_name] = $upstream_changes
+    $global:repo_change_descriptions[$repo_name] = @($upstream_changes)
 
     # Build commit message with subject and body
     $commit_message = $description.CommitSubject

--- a/update_deps/helper_scripts/github_repo_ops.ps1
+++ b/update_deps/helper_scripts/github_repo_ops.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft. All rights reserved.
+﻿# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 # GitHub repository operations for propagate_updates.ps1

--- a/update_deps/helper_scripts/pr_watch_utils.ps1
+++ b/update_deps/helper_scripts/pr_watch_utils.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft. All rights reserved.
+﻿# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 <#

--- a/update_deps/helper_scripts/propagation_state.ps1
+++ b/update_deps/helper_scripts/propagation_state.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft. All rights reserved.
+﻿# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 # Propagation state persistence functions for propagate_updates.ps1

--- a/update_deps/helper_scripts/success_animation.ps1
+++ b/update_deps/helper_scripts/success_animation.ps1
@@ -1,4 +1,4 @@
-# Copyright (c) Microsoft. All rights reserved.
+﻿# Copyright (c) Microsoft. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 # Fun animation showing dependencies propagating through a tree


### PR DESCRIPTION
Add UTF-8 BOM to helper scripts containing Unicode characters (box-drawing, emoji, status symbols). PowerShell 5.1 assumes ANSI encoding without a BOM, causing parse errors that prevented success_animation.ps1 from loading.

Fix null SHA error in collect-upstream-changes by wrapping stored change descriptions in @() to prevent PowerShell from unwrapping single-element arrays into bare hashtables. Added null guard on upstream_change.SHA as defense-in-depth.