### PR TITLE
[MrBot] Suppress CMake regeneration to fix MSB3371 ZERO_CHECK races

### DIFF
--- a/pipeline_templates/tasks/cmake.yml
+++ b/pipeline_templates/tasks/cmake.yml
@@ -80,7 +80,19 @@ steps:
         
         Push-Location $buildDir
         try {
-          $fullArgs = @($sourceDir) + ($cmakeArgs -split ' ') + @('-G', "$(cmakeGenerator)", '-A', "$(cmakeArch)")
+          # -DCMAKE_SUPPRESS_REGENERATION=ON removes the ZERO_CHECK project from
+          # generated Visual Studio solutions. ZERO_CHECK exists to detect changes
+          # to CMakeLists.txt and re-run cmake, but every other project in the
+          # solution depends on it. When MSBuild builds projects in parallel (/m),
+          # multiple workers race to write ZERO_CHECK.tlog\unsuccessfulbuild and
+          # fail with MSB3371 ("The process cannot access the file ... because it
+          # is being used by another process"). The failure is timing-dependent
+          # and is more likely under heavy I/O load (e.g. many parallel CI jobs
+          # on a shared pool). In CI the build directory is always freshly
+          # configured by this very step, so auto-regeneration on CMakeLists
+          # change is never needed. Harmless no-op for non-Visual-Studio
+          # generators (Ninja, Makefiles).
+          $fullArgs = @($sourceDir) + ($cmakeArgs -split ' ') + @('-G', "$(cmakeGenerator)", '-A', "$(cmakeArch)", '-DCMAKE_SUPPRESS_REGENERATION=ON')
           # Filter out empty strings
           $fullArgs = $fullArgs | Where-Object { $_ -ne '' }
           


### PR DESCRIPTION
Pass -DCMAKE_SUPPRESS_REGENERATION=ON in the cmake.yml template so every consumer of the template gets the fix automatically.

Symptom (intermittent, timing-dependent under load):
  error MSB3371: The file ARM64\\RelWithDebInfo\\ZERO_CHECK\\ZERO_CHECK.tlog\\unsuccessfulbuild
  cannot be created. The process cannot access the file ... because
  it is being used by another process.

Root cause: CMake's Visual Studio generator creates a ZERO_CHECK project that every other project in the solution depends on. When MSBuild builds projects in parallel (/m), multiple workers race to write the same tlog file.

CMAKE_SUPPRESS_REGENERATION=ON removes ZERO_CHECK entirely. The only trade-off is that cmake no longer auto-reruns when CMakeLists.txt changes, which is fine in CI (the build directory is freshly configured by this very step every job). No-op for Ninja/Makefile generators.