### PR TITLE
[MrBot] Add MAX_STAGE param; make ARM64 a blocking, test-running leg

### DIFF
--- a/pipeline_templates/build_all_flavors.yml
+++ b/pipeline_templates/build_all_flavors.yml
@@ -11,7 +11,8 @@ parameters:
     type: object
     default: ["ON", "OFF"]
 
-  # ARCH_TYPE_VALUES - architectures to build. ARM64 builds are optional (non-blocking).
+  # ARCH_TYPE_VALUES - architectures to build. Both x64 and ARM64 are blocking
+  # by default; tests run on both unless the caller passes MAX_STAGE=BUILD.
   - name: ARCH_TYPE_VALUES
     type: object
     default: ["x64", "ARM64"]
@@ -66,11 +67,21 @@ parameters:
     type: string
     default: "Azure-MessagingStore-Win-ARM64-Dpldsv6-v01"
 
-  # Controls whether tests are executed on ARM64 builds. When false (default),
-  # ARM64 builds compile tests but do not run them.
-  - name: run_arm64_tests
-    type: boolean
-    default: false
+  # MAX_STAGE controls how far the pipeline runs. Matches the convention used
+  # by EBS / ELS / GEO so callers can use one knob across all repos.
+  #   BUILD       - only compile binaries. Skip unit / int test execution.
+  #   UNIT_TESTS  - compile + run unit tests (CTest, VSTest, AppVerifier).
+  #   ALL         - alias for UNIT_TESTS in this template (no perf / integration
+  #                 stages live here). Accepted so callers that standardize on
+  #                 MAX_STAGE=ALL elsewhere don't get rejected.
+  # Applies symmetrically to all architectures (x64 and ARM64).
+  - name: MAX_STAGE
+    type: string
+    default: "UNIT_TESTS"
+    values:
+      - "BUILD"
+      - "UNIT_TESTS"
+      - "ALL"
 
   - name: skip_repo_validation
     type: boolean
@@ -101,8 +112,9 @@ jobs:
           # - jemalloc + ARM64: jemalloc doesn't support ARM64 on Windows
           # - appverifier + fsanitize: appverifier is incompatible with address sanitizer
           # - appverifier + run_test_suite_without_ctest: appverifier only works with ctest
-          # - appverifier + ARM64 (when tests are skipped): no point building just to skip tests
-          - ${{ if and( or( ne( GBALLOC_LL_TYPE , 'JEMALLOC' ), ne(FSANITIZE_TYPE, 'ON')), or( ne( GBALLOC_LL_TYPE , 'JEMALLOC' ), ne(ARCH_TYPE, 'ARM64')), or( ne(APP_VERIFIER, 'ON'), ne(FSANITIZE_TYPE, 'ON')), or( ne(APP_VERIFIER, 'ON'), eq(parameters.run_test_suite_without_ctest, '')), or( ne(APP_VERIFIER, 'ON'), ne(ARCH_TYPE, 'ARM64'), parameters.run_arm64_tests)) }}:
+          # - appverifier + MAX_STAGE=BUILD: appverifier is a test-execution mode; no point
+          #   building an APPVERIFIER=ON flavor when tests won't run.
+          - ${{ if and( or( ne( GBALLOC_LL_TYPE , 'JEMALLOC' ), ne(FSANITIZE_TYPE, 'ON')), or( ne( GBALLOC_LL_TYPE , 'JEMALLOC' ), ne(ARCH_TYPE, 'ARM64')), or( ne(APP_VERIFIER, 'ON'), ne(FSANITIZE_TYPE, 'ON')), or( ne(APP_VERIFIER, 'ON'), eq(parameters.run_test_suite_without_ctest, '')), or( ne(APP_VERIFIER, 'ON'), ne(parameters.MAX_STAGE, 'BUILD'))) }}:
             - template: build_and_run_tests.yml
               parameters:
                 BUILD_SUFFIX: _${{ BUILD_CONFIGURATION_TYPE }}_${{ GBALLOC_LL_TYPE }}_FSANITIZE_${{ FSANITIZE_TYPE }}_${{ ARCH_TYPE }}_APPVERIFIER_${{ APP_VERIFIER }}
@@ -111,6 +123,7 @@ jobs:
                 FSANITIZE_TYPE: ${{ FSANITIZE_TYPE }}
                 ARCH_TYPE: ${{ ARCH_TYPE }}
                 APP_VERIFIER: ${{ APP_VERIFIER }}
+                MAX_STAGE: ${{ parameters.MAX_STAGE }}
                 cmake_options: ${{ parameters.cmake_options }} ${{ parameters.additional_cmake_options }}
                 run_test_suite_without_ctest: ${{ parameters.run_test_suite_without_ctest }}
                 repo_root_override: ${{ parameters.repo_root_override }}
@@ -122,8 +135,3 @@ jobs:
                   pool_name: ${{ parameters.pool_name_arm64 }}
                 ${{ else }}:
                   pool_name: ${{ parameters.pool_name_x64 }}
-                # ARM64 builds are optional (non-blocking)
-                ${{ if eq(ARCH_TYPE, 'ARM64') }}:
-                  is_optional: true
-                  ${{ if not(parameters.run_arm64_tests) }}:
-                    skip_tests: true

--- a/pipeline_templates/build_all_flavors.yml
+++ b/pipeline_templates/build_all_flavors.yml
@@ -68,7 +68,7 @@ parameters:
     default: "Azure-MessagingStore-Win-ARM64-Dpldsv6-v01"
 
   # MAX_STAGE controls how far the pipeline runs. Matches the convention used
-  # by EBS / ELS / GEO so callers can use one knob across all repos.
+  # by downstream repos so callers can use one knob.
   #   BUILD       - only compile binaries. Skip unit / int test execution.
   #   UNIT_TESTS  - compile + run unit tests (CTest, VSTest, AppVerifier).
   #   ALL         - alias for UNIT_TESTS in this template (no perf / integration

--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -41,7 +41,7 @@ parameters:
     type: string
     default: "Azure-MessagingStore-Win-x64-Dadsv5-v19"
   # MAX_STAGE controls how far this leg runs. Matches the convention used by
-  # EBS / ELS / GEO and the parent build_all_flavors.yml.
+  # downstream repos and the parent build_all_flavors.yml.
   #   BUILD       - only compile binaries. Skip test execution.
   #   UNIT_TESTS  - compile + run unit tests (CTest, VSTest, AppVerifier).
   #   ALL         - alias for UNIT_TESTS in this template.

--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -37,17 +37,22 @@ parameters:
   - name: failOnMinTestsNotRun
     type: boolean
     default: true
-  # ARM64 builds are optional (continueOnError) so they don't block the gate
-  - name: is_optional
-    type: boolean
-    default: false
   - name: pool_name
     type: string
     default: "Azure-MessagingStore-Win-x64-Dadsv5-v19"
-  # When true, tests are built but not executed
-  - name: skip_tests
-    type: boolean
-    default: false
+  # MAX_STAGE controls how far this leg runs. Matches the convention used by
+  # EBS / ELS / GEO and the parent build_all_flavors.yml.
+  #   BUILD       - only compile binaries. Skip test execution.
+  #   UNIT_TESTS  - compile + run unit tests (CTest, VSTest, AppVerifier).
+  #   ALL         - alias for UNIT_TESTS in this template.
+  # Applied symmetrically to all architectures.
+  - name: MAX_STAGE
+    type: string
+    default: "UNIT_TESTS"
+    values:
+      - "BUILD"
+      - "UNIT_TESTS"
+      - "ALL"
   # When true, run NuGetAuthenticate and NuGetToolInstaller before cmake
   # so that execute_process(COMMAND nuget ...) can access private feeds.
   - name: setup_nuget
@@ -56,8 +61,7 @@ parameters:
 
 jobs:
 - job: build_and_run_tests_${{ parameters.BUILD_SUFFIX }}
-  displayName: 'Build and run tests, build_configuration: ${{ parameters.build_configuration }}, ${{ parameters.GBALLOC_LL_TYPE}}, ARCH_TYPE=${{ parameters.ARCH_TYPE }}, FSANITIZE_TYPE: ${{ parameters.FSANITIZE_TYPE}}, APP_VERIFIER=${{ parameters.APP_VERIFIER }}'
-  continueOnError: ${{ parameters.is_optional }}
+  displayName: 'Build and run tests, build_configuration: ${{ parameters.build_configuration }}, ${{ parameters.GBALLOC_LL_TYPE}}, ARCH_TYPE=${{ parameters.ARCH_TYPE }}, FSANITIZE_TYPE: ${{ parameters.FSANITIZE_TYPE}}, APP_VERIFIER=${{ parameters.APP_VERIFIER }}, MAX_STAGE=${{ parameters.MAX_STAGE }}'
 
   variables:
     ${{ if eq(parameters.FSANITIZE_TYPE, 'ON') }}:
@@ -85,8 +89,8 @@ jobs:
       GBALLOC_LL_TYPE: ${{ parameters.GBALLOC_LL_TYPE }}
       use_vld_option: ${{ variables.use_vld_option }}
 
-  # skip_tests is only honored for ARM64 builds - x64 always runs tests
-  - ${{ if or(not(parameters.skip_tests), ne(parameters.ARCH_TYPE, 'ARM64')) }}:
+  # Run tests only when MAX_STAGE is UNIT_TESTS or ALL. BUILD mode compiles only.
+  - ${{ if or(eq(parameters.MAX_STAGE, 'UNIT_TESTS'), eq(parameters.MAX_STAGE, 'ALL')) }}:
 
     # When APP_VERIFIER is OFF, run normal tests (VSTest, CTest)
     - ${{ if eq(parameters.APP_VERIFIER, 'OFF') }}:
@@ -109,19 +113,23 @@ jobs:
             configuration: '${{ parameters.build_configuration }}'
             failOnMinTestsNotRun: ${{ parameters.failOnMinTestsNotRun }}
             codeCoverageEnabled: ${{ ne(parameters.ARCH_TYPE, 'ARM64') }}
-            otherConsoleOptions: '/collect:"Code Coverage;Format=Xml"'
+            # Code Coverage collector is not validated on ARM64 build pools, so only
+            # request it on x64. Mirrors codeCoverageEnabled above; passed via
+            # otherConsoleOptions because tasks/vstest.yml currently appends
+            # otherConsoleOptions verbatim and does not honor codeCoverageEnabled itself.
+            ${{ if ne(parameters.ARCH_TYPE, 'ARM64') }}:
+              otherConsoleOptions: '/collect:"Code Coverage;Format=Xml"'
             runSettingsFile: '${{ parameters.repo_root_override }}/pipeline_templates/scripts/tests_native.runsettings'
             resultsFolder: '$(build.ArtifactStagingDirectory)/Test/VsTest/Results/${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}'
             testRunTitle: 'VsTest Native ${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}'
-            # ARM64 is experimental, continue on error
-            continueOnError: ${{ eq(parameters.ARCH_TYPE, 'ARM64') }}
 
-        # Publish code coverage results from vstest
-        - task: PublishCodeCoverageResults@2
-          displayName: '📰 Publish Code Coverage'
-          inputs:
-            summaryFileLocation: '$(build.ArtifactStagingDirectory)/Test/VsTest/Results/${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}/*/*.xml'
-            pathToSources: '$(Build.SourcesDirectory)'
+        # Publish code coverage results from vstest (x64 only - ARM64 does not collect coverage)
+        - ${{ if ne(parameters.ARCH_TYPE, 'ARM64') }}:
+          - task: PublishCodeCoverageResults@2
+            displayName: '📰 Publish Code Coverage'
+            inputs:
+              summaryFileLocation: '$(build.ArtifactStagingDirectory)/Test/VsTest/Results/${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}/*/*.xml'
+              pathToSources: '$(Build.SourcesDirectory)'
 
       # Use wrapper template for CTest - handles ARM64 native tools transparently
       - ${{ if eq(parameters.run_test_suite_without_ctest, '') }}:

--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -139,6 +139,19 @@ jobs:
             workingDirectory: '$(Build.BinariesDirectory)/c'
             configuration: '${{ parameters.build_configuration }}'
             outputJunit: 'ctest_results_${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}.xml'
+            # ARM64 + MAX_STAGE=UNIT_TESTS: limit ctest to unit tests only.
+            # Test names registered by build_test_artifacts (in c-testrunnerswitcher)
+            # are exactly ${whatIsBuilding}, which by convention end in _ut, _int,
+            # _perf, or _e2e. CMake's run_unittests / run_int_tests / run_perf_tests
+            # / run_e2e_tests options control registration; with the gate's default
+            # cmake_options every category gets registered, and ctest then runs them
+            # all. VSTest already filters to *_ut_*.dll via its discovery glob, but
+            # ctest does not. Filter at run time so BUILD-stage semantics still hold
+            # (int tests still compile on ARM64 - useful as a compile-only ratchet)
+            # while UNIT_TESTS strictly runs only _ut tests on ARM64.
+            # x64 keeps current behavior (callers manage scope via cmake_options).
+            ${{ if and(eq(parameters.ARCH_TYPE, 'ARM64'), eq(parameters.MAX_STAGE, 'UNIT_TESTS')) }}:
+              includeTests: '_ut$'
 
       - ${{ if eq(parameters.run_test_suite_without_ctest, '') }}:
         - task: PublishTestResults@2
@@ -178,6 +191,12 @@ jobs:
               outputJunit: 'ctest_appverifier_results_${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}.xml'
               excludeTests: '${{ parameters.appverifier_skip_tests_list }}'
               noTestsError: ${{ eq(parameters.appverifier_skip_tests_list, '') }}
+              # See the comment on the regular ctest invocation above for why ARM64 +
+              # MAX_STAGE=UNIT_TESTS limits to _ut tests. AppVerifier-helper itself
+              # configures appverif for whatever ctest -N returns; that config is
+              # harmless for tests that won't actually run.
+              ${{ if and(eq(parameters.ARCH_TYPE, 'ARM64'), eq(parameters.MAX_STAGE, 'UNIT_TESTS')) }}:
+                includeTests: '_ut$'
 
       - task: PublishTestResults@2
         displayName: '📊 Publish ctest results'

--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -139,19 +139,25 @@ jobs:
             workingDirectory: '$(Build.BinariesDirectory)/c'
             configuration: '${{ parameters.build_configuration }}'
             outputJunit: 'ctest_results_${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}.xml'
-            # ARM64 + MAX_STAGE=UNIT_TESTS: limit ctest to unit tests only.
+            # ARM64 + MAX_STAGE=UNIT_TESTS: skip non-unit-test categories on ARM64.
             # Test names registered by build_test_artifacts (in c-testrunnerswitcher)
-            # are exactly ${whatIsBuilding}, which by convention end in _ut, _int,
-            # _perf, or _e2e. CMake's run_unittests / run_int_tests / run_perf_tests
-            # / run_e2e_tests options control registration; with the gate's default
-            # cmake_options every category gets registered, and ctest then runs them
-            # all. VSTest already filters to *_ut_*.dll via its discovery glob, but
-            # ctest does not. Filter at run time so BUILD-stage semantics still hold
-            # (int tests still compile on ARM64 - useful as a compile-only ratchet)
-            # while UNIT_TESTS strictly runs only _ut tests on ARM64.
+            # follow the convention of ending in _ut, _int, _perf, or _e2e. CMake's
+            # run_unittests / run_int_tests / run_perf_tests / run_e2e_tests options
+            # control registration; with the gate's default cmake_options every
+            # category gets registered, and ctest then runs them all. VSTest already
+            # filters to *_ut_*.dll via its discovery glob, but ctest does not.
+            #
+            # We exclude (rather than include) so projects whose tests do not follow
+            # the _ut suffix convention - notably c-build-tools' own validate_*_test
+            # and RUN_REALS_CHECK_TEST gates - still run on ARM64 instead of being
+            # filtered out and tripping --no-tests=error.
+            #
+            # Filter at run time so BUILD-stage semantics still hold (int/perf/e2e
+            # still compile on ARM64 - useful as a compile-only ratchet) while
+            # UNIT_TESTS strictly skips them at run time on ARM64.
             # x64 keeps current behavior (callers manage scope via cmake_options).
             ${{ if and(eq(parameters.ARCH_TYPE, 'ARM64'), eq(parameters.MAX_STAGE, 'UNIT_TESTS')) }}:
-              includeTests: '_ut$'
+              excludeTests: '_int$|_perf$|_e2e$'
 
       - ${{ if eq(parameters.run_test_suite_without_ctest, '') }}:
         - task: PublishTestResults@2
@@ -189,14 +195,23 @@ jobs:
               workingDirectory: '$(Build.BinariesDirectory)/c'
               configuration: '${{ parameters.build_configuration }}'
               outputJunit: 'ctest_appverifier_results_${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}.xml'
-              excludeTests: '${{ parameters.appverifier_skip_tests_list }}'
               noTestsError: ${{ eq(parameters.appverifier_skip_tests_list, '') }}
               # See the comment on the regular ctest invocation above for why ARM64 +
-              # MAX_STAGE=UNIT_TESTS limits to _ut tests. AppVerifier-helper itself
-              # configures appverif for whatever ctest -N returns; that config is
-              # harmless for tests that won't actually run.
-              ${{ if and(eq(parameters.ARCH_TYPE, 'ARM64'), eq(parameters.MAX_STAGE, 'UNIT_TESTS')) }}:
-                includeTests: '_ut$'
+              # MAX_STAGE=UNIT_TESTS skips _int/_perf/_e2e tests. AppVerifier-helper
+              # itself configures appverif for whatever ctest -N returns; that config
+              # is harmless for tests that won't actually run.
+              # The exclude regex is composed from up to two sources:
+              #   1. The caller-provided appverifier_skip_tests_list (tests known to
+              #      misbehave under AppVerifier).
+              #   2. The ARM64+UNIT_TESTS test-category filter (_int|_perf|_e2e).
+              # All four mutually-exclusive cases are spelled out here because the
+              # parts have to be combined with a regex '|' separator.
+              ${{ if and(eq(parameters.ARCH_TYPE, 'ARM64'), eq(parameters.MAX_STAGE, 'UNIT_TESTS'), ne(parameters.appverifier_skip_tests_list, '')) }}:
+                excludeTests: '${{ parameters.appverifier_skip_tests_list }}|_int$|_perf$|_e2e$'
+              ${{ if and(eq(parameters.ARCH_TYPE, 'ARM64'), eq(parameters.MAX_STAGE, 'UNIT_TESTS'), eq(parameters.appverifier_skip_tests_list, '')) }}:
+                excludeTests: '_int$|_perf$|_e2e$'
+              ${{ if or(ne(parameters.ARCH_TYPE, 'ARM64'), ne(parameters.MAX_STAGE, 'UNIT_TESTS')) }}:
+                excludeTests: '${{ parameters.appverifier_skip_tests_list }}'
 
       - task: PublishTestResults@2
         displayName: '📊 Publish ctest results'

--- a/pipeline_templates/disable_appverifier.yml
+++ b/pipeline_templates/disable_appverifier.yml
@@ -11,4 +11,5 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1'
+      arguments: '-appverifPath "$(appverifPath)"'
     condition: always()

--- a/pipeline_templates/disable_appverifier.yml
+++ b/pipeline_templates/disable_appverifier.yml
@@ -1,5 +1,8 @@
 # Convenience helper to disable application verifier for all processes
 # May be useful as a cleanup task in case the application verifier state leaks from other canceled jobs
+#
+# Reads $(appverifPath) and $(ctestPath) emitted by discover_native_tools.yml. Both default to
+# empty literal expansion if unset, which the helper script treats as "fall back to env / PATH".
 
 parameters:
  - name: repo_root
@@ -11,5 +14,5 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1'
-      arguments: '-appverifPath "$(appverifPath)"'
+      arguments: '-appverifPath "$(appverifPath)" -ctestPath "$(ctestPath)"'
     condition: always()

--- a/pipeline_templates/disable_appverifier.yml
+++ b/pipeline_templates/disable_appverifier.yml
@@ -1,8 +1,10 @@
-# Convenience helper to disable application verifier for all processes
-# May be useful as a cleanup task in case the application verifier state leaks from other canceled jobs
+# Convenience helper to disable application verifier for all processes.
+# May be useful as a cleanup task in case the application verifier state leaks
+# from other canceled jobs.
 #
-# Reads $(appverifPath) and $(ctestPath) emitted by discover_native_tools.yml. Both default to
-# empty literal expansion if unset, which the helper script treats as "fall back to env / PATH".
+# Forwards $(appverifPath) emitted by discover_native_tools.yml to the helper
+# script. Detection failures abort discover_native_tools.yml directly, so by the
+# time this template runs $(appverifPath) is guaranteed to be a valid path.
 
 parameters:
  - name: repo_root
@@ -14,5 +16,5 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1'
-      arguments: '-appverifPath "$(appverifPath)" -ctestPath "$(ctestPath)"'
+      arguments: '-appverifPath "$(appverifPath)"'
     condition: always()

--- a/pipeline_templates/discover_native_tools.yml
+++ b/pipeline_templates/discover_native_tools.yml
@@ -231,7 +231,33 @@ steps:
             Write-Host "##[warning]$vstestExeName not found"
         }
         Write-Host ""
-        
+
+        # Find appverif.exe (Application Verifier driver). Optional - only consumed
+        # by repos that opt into AppVerifier-enabled CTest runs (APP_VERIFIER=ON).
+        # Some agent images install Application Verifier outside of PATH (the
+        # standalone installer drops it under "Program Files (x86)\Application
+        # Verifier" rather than System32), so probe known locations after PATH.
+        $appverifPath = $null
+        $appverifFromPath = Get-Command appverif.exe -ErrorAction SilentlyContinue
+        if ($appverifFromPath) {
+            $appverifPath = $appverifFromPath.Source
+        } else {
+            $appverifCandidates = @(
+                (Join-Path $env:windir 'System32\appverif.exe'),
+                (Join-Path ${env:ProgramFiles(x86)} 'Application Verifier\appverif.exe'),
+                (Join-Path $env:ProgramFiles 'Application Verifier\appverif.exe')
+            ) | Where-Object { $_ -and (Test-Path $_) }
+            if ($appverifCandidates.Count -gt 0) { $appverifPath = $appverifCandidates[0] }
+        }
+
+        if ($appverifPath -and (Test-Path $appverifPath)) {
+            Write-Host "appverif: $appverifPath"
+            Write-Host "##vso[task.setvariable variable=appverifPath]$appverifPath"
+        } else {
+            Write-Host "##[warning]appverif.exe not found via PATH or known install locations - AppVerifier-enabled jobs will skip"
+        }
+        Write-Host ""
+
         # Set architecture variables for use in build commands
         Write-Host "##vso[task.setvariable variable=cmakeArch]$cmakeArch"
         Write-Host "##vso[task.setvariable variable=targetPlatform]$targetPlatform"
@@ -284,6 +310,7 @@ steps:
         if ($msbuildPath) { $toolsToVerify['MSBuild.exe'] = $msbuildPath }
         if ($dumpbinPath) { $toolsToVerify['dumpbin.exe'] = $dumpbinPath }
         if ($vstestPath) { $toolsToVerify['vstest.console.exe'] = $vstestPath }
+        if ($appverifPath) { $toolsToVerify['appverif.exe'] = $appverifPath }
         
         foreach ($tool in $toolsToVerify.GetEnumerator()) {
             $toolArch = Get-PEArchitecture -FilePath $tool.Value

--- a/pipeline_templates/discover_native_tools.yml
+++ b/pipeline_templates/discover_native_tools.yml
@@ -12,6 +12,7 @@
 #   $(msbuildPath)  - Path to MSBuild.exe (architecture-specific)
 #   $(dumpbinPath)  - Path to dumpbin.exe (architecture-specific)
 #   $(vstestPath)   - Path to vstest.console.exe (architecture-specific)
+#   $(appverifPath) - Path to appverif.exe (empty string if not installed)
 #   $(cmakeArch)    - CMake architecture flag (x64, Win32, ARM64)
 #   $(targetPlatform) - MSBuild platform (x64, Win32, ARM64)
 #   $(cmakeGenerator) - CMake generator string (e.g., "Visual Studio 17 2022")
@@ -186,7 +187,74 @@ steps:
             Write-Host "##[warning]dumpbin not found - reals_check may fail"
         }
         Write-Host ""
-        
+
+        # Find Application Verifier (appverif.exe)
+        # AppVerifier is a configuration tool that sets verifier state for target image
+        # names. Its own PE architecture is informational only - it can configure verifier
+        # settings for binaries of any architecture. It is therefore intentionally NOT
+        # included in the strict PE-architecture verification block below.
+        # Search order is target-architecture-aware:
+        #   ARM64 host : prefer native ARM64 build, fall back to x64 with a loud warning
+        #   x64/x86    : prefer x64 build
+        # Then common alternative install locations, then PATH (for legacy build pools).
+        $appverifPath = $null
+        $appverifPrimary = @()
+        if ($arch -eq "ARM64") {
+            $appverifPrimary += "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\arm64\appverif.exe"
+            $appverifPrimary += "$env:ProgramFiles\Windows Kits\10\Debuggers\arm64\appverif.exe"
+        } else {
+            $appverifPrimary += "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\x64\appverif.exe"
+            $appverifPrimary += "$env:ProgramFiles\Windows Kits\10\Debuggers\x64\appverif.exe"
+        }
+        # Common alternative locations (any architecture)
+        $appverifAlternatives = @(
+            "${env:ProgramFiles(x86)}\Application Verifier\appverif.exe",
+            "$env:ProgramFiles\Application Verifier\appverif.exe",
+            "$env:SystemRoot\System32\appverif.exe"
+        )
+
+        foreach ($candidate in ($appverifPrimary + $appverifAlternatives)) {
+            if ($candidate -and (Test-Path $candidate)) {
+                $appverifPath = $candidate
+                break
+            }
+        }
+
+        # ARM64 last-resort fallback to x64 AppVerifier (with a loud warning that
+        # ARM64 test binary instrumentation is unverified with this fallback).
+        if ($arch -eq "ARM64" -and -not $appverifPath) {
+            $appverifArm64Fallbacks = @(
+                "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\x64\appverif.exe",
+                "$env:ProgramFiles\Windows Kits\10\Debuggers\x64\appverif.exe"
+            )
+            foreach ($candidate in $appverifArm64Fallbacks) {
+                if ($candidate -and (Test-Path $candidate)) {
+                    $appverifPath = $candidate
+                    Write-Host "##[warning]ARM64 AppVerifier not found; falling back to x64 AppVerifier at $appverifPath. ARM64 test binary instrumentation is unverified with this fallback."
+                    break
+                }
+            }
+        }
+
+        # PATH fallback (legacy build pools where appverif.exe was placed on PATH manually)
+        if (-not $appverifPath) {
+            $appverifCmd = Get-Command appverif.exe -ErrorAction SilentlyContinue
+            if ($appverifCmd) {
+                $appverifPath = $appverifCmd.Source
+            }
+        }
+
+        if ($appverifPath) {
+            Write-Host "appverif: $appverifPath"
+            Write-Host "##vso[task.setvariable variable=appverifPath]$appverifPath"
+        } else {
+            # Always emit the variable (empty) so consumers see "" instead of an
+            # unresolved $(appverifPath) literal in script arguments.
+            Write-Host "##vso[task.setvariable variable=appverifPath]"
+            Write-Host "##[warning]appverif.exe not found - AppVerifier steps will be skipped"
+        }
+        Write-Host ""
+
         # Find vstest.console.exe
         # Path pattern: <vsPath>\Common7\IDE\CommonExtensions\<Microsoft|Platform>\TestPlatform
         $vstestPath = $null
@@ -229,32 +297,6 @@ steps:
             Write-Host "##vso[task.setvariable variable=vstestPath]$vstestPath"
         } else {
             Write-Host "##[warning]$vstestExeName not found"
-        }
-        Write-Host ""
-
-        # Find appverif.exe (Application Verifier driver). Optional - only consumed
-        # by repos that opt into AppVerifier-enabled CTest runs (APP_VERIFIER=ON).
-        # Some agent images install Application Verifier outside of PATH (the
-        # standalone installer drops it under "Program Files (x86)\Application
-        # Verifier" rather than System32), so probe known locations after PATH.
-        $appverifPath = $null
-        $appverifFromPath = Get-Command appverif.exe -ErrorAction SilentlyContinue
-        if ($appverifFromPath) {
-            $appverifPath = $appverifFromPath.Source
-        } else {
-            $appverifCandidates = @(
-                (Join-Path $env:windir 'System32\appverif.exe'),
-                (Join-Path ${env:ProgramFiles(x86)} 'Application Verifier\appverif.exe'),
-                (Join-Path $env:ProgramFiles 'Application Verifier\appverif.exe')
-            ) | Where-Object { $_ -and (Test-Path $_) }
-            if ($appverifCandidates.Count -gt 0) { $appverifPath = $appverifCandidates[0] }
-        }
-
-        if ($appverifPath -and (Test-Path $appverifPath)) {
-            Write-Host "appverif: $appverifPath"
-            Write-Host "##vso[task.setvariable variable=appverifPath]$appverifPath"
-        } else {
-            Write-Host "##[warning]appverif.exe not found via PATH or known install locations - AppVerifier-enabled jobs will skip"
         }
         Write-Host ""
 
@@ -310,7 +352,8 @@ steps:
         if ($msbuildPath) { $toolsToVerify['MSBuild.exe'] = $msbuildPath }
         if ($dumpbinPath) { $toolsToVerify['dumpbin.exe'] = $dumpbinPath }
         if ($vstestPath) { $toolsToVerify['vstest.console.exe'] = $vstestPath }
-        if ($appverifPath) { $toolsToVerify['appverif.exe'] = $appverifPath }
+        # appverif.exe is intentionally NOT verified here - it is a configuration tool
+        # whose own PE architecture is not required to match the target architecture.
         
         foreach ($tool in $toolsToVerify.GetEnumerator()) {
             $toolArch = Get-PEArchitecture -FilePath $tool.Value

--- a/pipeline_templates/discover_native_tools.yml
+++ b/pipeline_templates/discover_native_tools.yml
@@ -197,6 +197,18 @@ steps:
         # informational only - it can configure verifier settings for binaries of any
         # architecture - and is therefore intentionally NOT included in the strict
         # PE-architecture verification block below.
+        #
+        # WOW64 file-system redirection note:
+        # When this script runs in an x86-emulated PowerShell on a 64-bit / ARM64
+        # host (for example, the 1ES ARM64 hosted pool agent currently runs as x86
+        # under emulation), accesses to "$env:SystemRoot\System32" are silently
+        # redirected to "$env:SystemRoot\SysWOW64", which contains x86 binaries -
+        # not the native ARM64 / x64 build of appverif.exe that lives in real
+        # System32. The "Sysnative" alias bypasses that redirector and exposes the
+        # native System32 to x86 processes; on a native 64-bit / ARM64 process
+        # Sysnative simply does not exist (Test-Path returns false) and we fall
+        # through to System32. Probe Sysnative first so the x86-emulated case
+        # actually sees the native binary.
         $appverifPath = $null
         $appverifCandidates = @()
         if ($arch -eq "ARM64") {
@@ -207,6 +219,7 @@ steps:
         $appverifCandidates += "$env:ProgramFiles\Windows Kits\10\Debuggers\x64\appverif.exe"
         $appverifCandidates += "${env:ProgramFiles(x86)}\Application Verifier\appverif.exe"
         $appverifCandidates += "$env:ProgramFiles\Application Verifier\appverif.exe"
+        $appverifCandidates += "$env:SystemRoot\Sysnative\appverif.exe"
         $appverifCandidates += "$env:SystemRoot\System32\appverif.exe"
 
         foreach ($candidate in $appverifCandidates) {

--- a/pipeline_templates/discover_native_tools.yml
+++ b/pipeline_templates/discover_native_tools.yml
@@ -12,7 +12,7 @@
 #   $(msbuildPath)  - Path to MSBuild.exe (architecture-specific)
 #   $(dumpbinPath)  - Path to dumpbin.exe (architecture-specific)
 #   $(vstestPath)   - Path to vstest.console.exe (architecture-specific)
-#   $(appverifPath) - Path to appverif.exe (empty string if not installed)
+#   $(appverifPath) - Path to appverif.exe (mandatory; discovery aborts if not found)
 #   $(cmakeArch)    - CMake architecture flag (x64, Win32, ARM64)
 #   $(targetPlatform) - MSBuild platform (x64, Win32, ARM64)
 #   $(cmakeGenerator) - CMake generator string (e.g., "Visual Studio 17 2022")
@@ -188,55 +188,34 @@ steps:
         }
         Write-Host ""
 
-        # Find Application Verifier (appverif.exe)
-        # AppVerifier is a configuration tool that sets verifier state for target image
-        # names. Its own PE architecture is informational only - it can configure verifier
-        # settings for binaries of any architecture. It is therefore intentionally NOT
-        # included in the strict PE-architecture verification block below.
-        # Search order is target-architecture-aware:
-        #   ARM64 host : prefer native ARM64 build, fall back to x64 with a loud warning
-        #   x64/x86    : prefer x64 build
-        # Then common alternative install locations, then PATH (for legacy build pools).
+        # Find Application Verifier (appverif.exe).
+        # Detection is mandatory: if appverif.exe cannot be located, this discovery
+        # step aborts the job. Every consumer of c-build-tools is expected to run on
+        # build pools that have AppVerifier installed; a missing appverif is treated
+        # as an environmental error, not as a condition the helper should paper over.
+        # AppVerifier is a configuration tool whose own PE architecture is
+        # informational only - it can configure verifier settings for binaries of any
+        # architecture - and is therefore intentionally NOT included in the strict
+        # PE-architecture verification block below.
         $appverifPath = $null
-        $appverifPrimary = @()
+        $appverifCandidates = @()
         if ($arch -eq "ARM64") {
-            $appverifPrimary += "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\arm64\appverif.exe"
-            $appverifPrimary += "$env:ProgramFiles\Windows Kits\10\Debuggers\arm64\appverif.exe"
-        } else {
-            $appverifPrimary += "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\x64\appverif.exe"
-            $appverifPrimary += "$env:ProgramFiles\Windows Kits\10\Debuggers\x64\appverif.exe"
+            $appverifCandidates += "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\arm64\appverif.exe"
+            $appverifCandidates += "$env:ProgramFiles\Windows Kits\10\Debuggers\arm64\appverif.exe"
         }
-        # Common alternative locations (any architecture)
-        $appverifAlternatives = @(
-            "${env:ProgramFiles(x86)}\Application Verifier\appverif.exe",
-            "$env:ProgramFiles\Application Verifier\appverif.exe",
-            "$env:SystemRoot\System32\appverif.exe"
-        )
+        $appverifCandidates += "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\x64\appverif.exe"
+        $appverifCandidates += "$env:ProgramFiles\Windows Kits\10\Debuggers\x64\appverif.exe"
+        $appverifCandidates += "${env:ProgramFiles(x86)}\Application Verifier\appverif.exe"
+        $appverifCandidates += "$env:ProgramFiles\Application Verifier\appverif.exe"
+        $appverifCandidates += "$env:SystemRoot\System32\appverif.exe"
 
-        foreach ($candidate in ($appverifPrimary + $appverifAlternatives)) {
+        foreach ($candidate in $appverifCandidates) {
             if ($candidate -and (Test-Path $candidate)) {
                 $appverifPath = $candidate
                 break
             }
         }
 
-        # ARM64 last-resort fallback to x64 AppVerifier (with a loud warning that
-        # ARM64 test binary instrumentation is unverified with this fallback).
-        if ($arch -eq "ARM64" -and -not $appverifPath) {
-            $appverifArm64Fallbacks = @(
-                "${env:ProgramFiles(x86)}\Windows Kits\10\Debuggers\x64\appverif.exe",
-                "$env:ProgramFiles\Windows Kits\10\Debuggers\x64\appverif.exe"
-            )
-            foreach ($candidate in $appverifArm64Fallbacks) {
-                if ($candidate -and (Test-Path $candidate)) {
-                    $appverifPath = $candidate
-                    Write-Host "##[warning]ARM64 AppVerifier not found; falling back to x64 AppVerifier at $appverifPath. ARM64 test binary instrumentation is unverified with this fallback."
-                    break
-                }
-            }
-        }
-
-        # PATH fallback (legacy build pools where appverif.exe was placed on PATH manually)
         if (-not $appverifPath) {
             $appverifCmd = Get-Command appverif.exe -ErrorAction SilentlyContinue
             if ($appverifCmd) {
@@ -244,15 +223,15 @@ steps:
             }
         }
 
-        if ($appverifPath) {
-            Write-Host "appverif: $appverifPath"
-            Write-Host "##vso[task.setvariable variable=appverifPath]$appverifPath"
-        } else {
-            # Always emit the variable (empty) so consumers see "" instead of an
-            # unresolved $(appverifPath) literal in script arguments.
-            Write-Host "##vso[task.setvariable variable=appverifPath]"
-            Write-Host "##[warning]appverif.exe not found - AppVerifier steps will be skipped"
+        if (-not $appverifPath) {
+            $searched = ($appverifCandidates | ForEach-Object { "  $_" }) -join "`n"
+            Write-Host "##vso[task.logissue type=error]appverif.exe could not be located. Searched the following locations and PATH:`n$searched"
+            Write-Host "##[error]appverif.exe is required on every build pool. Aborting native tools discovery."
+            exit 1
         }
+
+        Write-Host "appverif: $appverifPath"
+        Write-Host "##vso[task.setvariable variable=appverifPath]$appverifPath"
         Write-Host ""
 
         # Find vstest.console.exe

--- a/pipeline_templates/run_ctests_with_appverifier.yml
+++ b/pipeline_templates/run_ctests_with_appverifier.yml
@@ -24,7 +24,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1'
-      arguments: '-on -binaryNameSuffix ${{ parameters.binary_name_suffix }} -ctestArgs "${{ parameters.ctest_additional_args }}" -appVerifierEnable "${{ parameters.app_verifier_enable }}" -appVerifierAdditionalProperties "${{ parameters.app_verifier_additional_properties }}"'
+      arguments: '-on -binaryNameSuffix ${{ parameters.binary_name_suffix }} -ctestArgs "${{ parameters.ctest_additional_args }}" -appVerifierEnable "${{ parameters.app_verifier_enable }}" -appVerifierAdditionalProperties "${{ parameters.app_verifier_additional_properties }}" -appverifPath "$(appverifPath)"'
       workingDirectory: ${{ parameters.ctest_tests_bin_directory }}
 
   # see https://learn.microsoft.com/en-us/azure/devops/pipelines/process/template-expressions?view=azure-devops#iterative-insertion
@@ -40,4 +40,5 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1'
+      arguments: '-appverifPath "$(appverifPath)"'
     condition: always()

--- a/pipeline_templates/run_ctests_with_appverifier.yml
+++ b/pipeline_templates/run_ctests_with_appverifier.yml
@@ -3,8 +3,10 @@
 # If the list of tests from ctest is filtered, pass the filter arguments as ctest_additional_args so appverifier is enabled for the correct binaries
 # The steps in the steps parameter will all be run after enabling app verifier
 #
-# Reads $(appverifPath) and $(ctestPath) emitted by discover_native_tools.yml. Both default to
-# empty literal expansion if unset, which the helper script treats as "fall back to env / PATH".
+# Forwards $(appverifPath) and $(ctestPath) emitted by discover_native_tools.yml
+# to the helper script. Detection failures abort discover_native_tools.yml
+# directly, so both pipeline variables are guaranteed to be valid paths by the
+# time this template runs.
 
 parameters:
  - name: repo_root

--- a/pipeline_templates/run_ctests_with_appverifier.yml
+++ b/pipeline_templates/run_ctests_with_appverifier.yml
@@ -2,6 +2,9 @@
 # it will disable app verifier after running
 # If the list of tests from ctest is filtered, pass the filter arguments as ctest_additional_args so appverifier is enabled for the correct binaries
 # The steps in the steps parameter will all be run after enabling app verifier
+#
+# Reads $(appverifPath) and $(ctestPath) emitted by discover_native_tools.yml. Both default to
+# empty literal expansion if unset, which the helper script treats as "fall back to env / PATH".
 
 parameters:
  - name: repo_root
@@ -24,7 +27,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1'
-      arguments: '-on -binaryNameSuffix ${{ parameters.binary_name_suffix }} -ctestArgs "${{ parameters.ctest_additional_args }}" -appVerifierEnable "${{ parameters.app_verifier_enable }}" -appVerifierAdditionalProperties "${{ parameters.app_verifier_additional_properties }}" -appverifPath "$(appverifPath)"'
+      arguments: '-on -binaryNameSuffix ${{ parameters.binary_name_suffix }} -ctestArgs "${{ parameters.ctest_additional_args }}" -appVerifierEnable "${{ parameters.app_verifier_enable }}" -appVerifierAdditionalProperties "${{ parameters.app_verifier_additional_properties }}" -appverifPath "$(appverifPath)" -ctestPath "$(ctestPath)"'
       workingDirectory: ${{ parameters.ctest_tests_bin_directory }}
 
   # see https://learn.microsoft.com/en-us/azure/devops/pipelines/process/template-expressions?view=azure-devops#iterative-insertion
@@ -40,5 +43,5 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1'
-      arguments: '-appverifPath "$(appverifPath)"'
+      arguments: '-appverifPath "$(appverifPath)" -ctestPath "$(ctestPath)"'
     condition: always()

--- a/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
+++ b/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
@@ -43,15 +43,41 @@ param(
     [Parameter()][string]$appVerifierEnable = "exceptions handles heaps leak memory threadpool tls",
     [Parameter()][string]$appVerifierAdditionalProperties = "",
     [Parameter()][string]$ctestArgs = "",
-    [Parameter()][string]$binaryNameSuffix
+    [Parameter()][string]$binaryNameSuffix,
+    # Path to appverif.exe. Normally set by discover_native_tools.yml as the
+    # $(appverifPath) pipeline variable. If empty / unresolved / pointing at a
+    # non-existent file, the script probes PATH and known install locations as a
+    # fallback so it remains usable when invoked outside the discover-tools flow.
+    [Parameter()][string]$appverifPath = ""
 )
 
-# Check if appverif is available (not installed on ARM64 build pools)
-$appverifPath = Get-Command appverif -ErrorAction SilentlyContinue
-if (-not $appverifPath) {
-    Write-Output "Application Verifier (appverif) is not installed on this machine. Skipping."
+# Resolve appverif.exe location: caller-provided path > PATH > known install locations.
+# Some agent images install Application Verifier outside of PATH (the standalone
+# installer drops it under "Program Files (x86)\Application Verifier" rather than
+# System32), so PATH alone is not sufficient.
+$appverifExe = $null
+if ($appverifPath -and (Test-Path $appverifPath)) {
+    $appverifExe = $appverifPath
+} else {
+    $appverifFromPath = Get-Command appverif.exe -ErrorAction SilentlyContinue
+    if ($appverifFromPath) {
+        $appverifExe = $appverifFromPath.Source
+    } else {
+        $candidates = @(
+            (Join-Path $env:windir 'System32\appverif.exe'),
+            (Join-Path ${env:ProgramFiles(x86)} 'Application Verifier\appverif.exe'),
+            (Join-Path $env:ProgramFiles 'Application Verifier\appverif.exe')
+        ) | Where-Object { $_ -and (Test-Path $_) }
+        if ($candidates.Count -gt 0) { $appverifExe = $candidates[0] }
+    }
+}
+
+if (-not $appverifExe) {
+    Write-Output "Application Verifier (appverif.exe) not found via PATH or known install locations. Skipping."
     exit 0
 }
+
+Write-Output "Using Application Verifier at: $appverifExe"
 
 if ($on)
 {
@@ -69,7 +95,7 @@ if ($on)
             if ($on)
             {
                 Write-Output "Enabling appverifier for $exeName"
-                & appverif -enable $appVerifierEnable.Split() -for $exeName -with exceptiononstop=true $appVerifierAdditionalProperties.Split()
+                & $appverifExe -enable $appVerifierEnable.Split() -for $exeName -with exceptiononstop=true $appVerifierAdditionalProperties.Split()
             }
         }
     }
@@ -77,5 +103,5 @@ if ($on)
 else
 {
     Write-Output "Disabling all appverifier settings"
-    & appverif -disable * -for *
+    & $appverifExe -disable * -for *
 }

--- a/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
+++ b/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
@@ -6,7 +6,13 @@
 
   .DESCRIPTION
   This can enable Application Verifier for all tests (with optional arguments to filter tests) from ctest.
-  An optional argument can also be provided to select which app verifier options are used
+  An optional argument can also be provided to select which app verifier options are used.
+
+  AppVerifier and ctest paths are NOT discovered by this script. Discovery is the
+  responsibility of discover_native_tools.yml, which sets the $(appverifPath) and
+  $(ctestPath) pipeline variables that callers MUST forward to this script via the
+  -appverifPath and -ctestPath parameters. If either path is missing, empty, or
+  invalid, this script aborts with a non-zero exit code.
 
   .PARAMETER on
   When set, this enables Application Verifier for the tests listed by ctest, otherwise, this disables Application Verifier for all images
@@ -25,17 +31,14 @@
   Suffix for binary names of tests. E.g. if ctest returns some test names like foo, bar, and the binaries are foo_x.exe and bar_x.exe then this should be "_x.exe"
 
   .PARAMETER appverifPath
-  Optional explicit path to appverif.exe. When omitted, the script falls back (in order) to the
-  APPVERIF_PATH env var, the ADO-injected APPVERIFPATH env var (from the pipeline variable
-  emitted by discover_native_tools.yml), and finally the system PATH. If none resolve to an
-  existing file the script logs a warning and exits 0 (preserves existing skip-when-missing
-  behavior on build pools that do not have AppVerifier installed, e.g. legacy ARM64 pools).
+  Required. Full path to appverif.exe, as discovered and emitted by
+  discover_native_tools.yml as the $(appverifPath) pipeline variable. The script
+  aborts if this is empty, an unresolved ADO macro literal, or refers to a missing
+  file. There is no PATH or env-var fallback - discovery is canonical.
 
   .PARAMETER ctestPath
-  Optional explicit path to ctest.exe (used in the -on path to enumerate tests). When omitted,
-  the script falls back to the ADO-injected CTESTPATH env var (from discover_native_tools.yml)
-  and finally to a hardcoded VS 2022 Enterprise location. If ctest cannot be found in -on mode
-  the script fails loudly so the AppVerifier gate cannot silently enable zero binaries.
+  Required when -on is set (used to enumerate tests). Same contract as
+  -appverifPath: must be the discovered $(ctestPath) value. There is no fallback.
 
   .INPUTS
   None. You cannot pipe objects to appverifier_ctest_tests_helper.ps1.
@@ -44,10 +47,10 @@
   None. appverifier_ctest_tests_helper.ps1 does not generate any output.
 
   .EXAMPLE
-  PS> .\appverifier_ctest_tests_helper.ps1
-  By default, disables app verifier for all processes
+  PS> .\appverifier_ctest_tests_helper.ps1 -appverifPath C:\path\to\appverif.exe
+  Disables app verifier for all processes
 
-  PS> .\appverifier_ctest_tests_helper.ps1 -on
+  PS> .\appverifier_ctest_tests_helper.ps1 -on -appverifPath C:\path\to\appverif.exe -ctestPath C:\path\to\ctest.exe
   Enables app verifier for all test binaries found in ctest
 #>
 
@@ -61,66 +64,37 @@ param(
     [Parameter()][string]$ctestPath = ""
 )
 
-# Treat unresolved ADO macro literals (e.g. "$(appverifPath)" passed when the pipeline
-# variable was never set) and empty/whitespace strings as "not provided".
-function Resolve-OptionalPath
+# Validate a path that was supposed to come from discover_native_tools.yml.
+# Treats empty/whitespace and unresolved ADO macro literals like "$(appverifPath)"
+# as missing, and ensures the path actually exists on disk. Any failure aborts
+# the script with a clear error - there are no fallbacks.
+function Assert-DiscoveredPath
 {
-    param([string]$Value)
-    if ([string]::IsNullOrWhiteSpace($Value)) { return $null }
-    if ($Value -match '^\$\(.+\)$') { return $null }
-    return $Value
+    param(
+        [string]$Value,
+        [string]$Name
+    )
+    if ([string]::IsNullOrWhiteSpace($Value) -or $Value -match '^\$\(.+\)$')
+    {
+        Write-Host "##vso[task.logissue type=error]$Name was not provided. discover_native_tools.yml must run before this script and successfully resolve $Name; the corresponding pipeline variable must be forwarded to this script."
+        exit 1
+    }
+    if (-not (Test-Path $Value))
+    {
+        Write-Host "##vso[task.logissue type=error]$Name resolved to '$Value', which does not exist on disk."
+        exit 1
+    }
 }
 
-# Resolve appverif.exe in priority order:
-#   1. -appverifPath parameter (passed by run_ctests_with_appverifier.yml /
-#      disable_appverifier.yml from the $(appverifPath) discovered by discover_native_tools.yml)
-#   2. APPVERIF_PATH env var (manual override)
-#   3. APPVERIFPATH env var (ADO-injected from pipeline variable 'appverifPath')
-#   4. Get-Command appverif.exe (PATH lookup; legacy build pools)
-$resolvedAppverifPath = Resolve-OptionalPath $appverifPath
-if (-not $resolvedAppverifPath) { $resolvedAppverifPath = Resolve-OptionalPath $env:APPVERIF_PATH }
-if (-not $resolvedAppverifPath) { $resolvedAppverifPath = Resolve-OptionalPath $env:APPVERIFPATH }
-if (-not $resolvedAppverifPath)
-{
-    $appverifCmd = Get-Command appverif.exe -ErrorAction SilentlyContinue
-    if ($appverifCmd) { $resolvedAppverifPath = $appverifCmd.Source }
-}
-if ($resolvedAppverifPath -and -not (Test-Path $resolvedAppverifPath))
-{
-    Write-Host "##vso[task.logissue type=warning]Resolved AppVerifier path '$resolvedAppverifPath' does not exist; ignoring."
-    $resolvedAppverifPath = $null
-}
-
-if (-not $resolvedAppverifPath) {
-    # Surface as an ADO warning so the build summary makes the silent skip visible.
-    Write-Host "##vso[task.logissue type=warning]Application Verifier (appverif.exe) is not available on this machine. AppVerifier steps will be skipped."
-    Write-Output "Application Verifier (appverif) is not installed on this machine. Skipping."
-    exit 0
-}
-Write-Output "Using Application Verifier at: $resolvedAppverifPath"
+Assert-DiscoveredPath -Value $appverifPath -Name "appverifPath"
+Write-Output "Using Application Verifier at: $appverifPath"
 
 if ($on)
 {
-    # Resolve ctest.exe in priority order:
-    #   1. -ctestPath parameter (passed from $(ctestPath) discovered by discover_native_tools.yml)
-    #   2. CTESTPATH env var (ADO-injected from pipeline variable 'ctestPath')
-    #   3. Hardcoded VS 2022 Enterprise path (legacy fallback)
-    $resolvedCtestPath = Resolve-OptionalPath $ctestPath
-    if (-not $resolvedCtestPath) { $resolvedCtestPath = Resolve-OptionalPath $env:CTESTPATH }
-    if (-not $resolvedCtestPath)
-    {
-        $resolvedCtestPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe"
-    }
-    if (-not (Test-Path $resolvedCtestPath))
-    {
-        # In -on mode this MUST fail loudly: silently enumerating zero tests would leave the
-        # AppVerifier gate green while no binaries were actually instrumented.
-        Write-Host "##vso[task.logissue type=error]ctest.exe not found at '$resolvedCtestPath'. Cannot enumerate tests for AppVerifier instrumentation."
-        exit 1
-    }
-    Write-Output "Using CTest at: $resolvedCtestPath"
+    Assert-DiscoveredPath -Value $ctestPath -Name "ctestPath"
+    Write-Output "Using CTest at: $ctestPath"
 
-    $allTests = & $resolvedCtestPath -N $ctestArgs.Split()
+    $allTests = & $ctestPath -N $ctestArgs.Split()
     $testsArray = $allTests.Split([Environment]::NewLine,[Stringsplitoptions]::RemoveEmptyEntries).trim()
 
     foreach ($t in $testsArray)
@@ -132,12 +106,12 @@ if ($on)
             $testName = ($t -split ":")[1].Trim()
             $exeName = "$($testName)$($binaryNameSuffix)"
             Write-Output "Enabling appverifier for $exeName"
-            & $resolvedAppverifPath -enable $appVerifierEnable.Split() -for $exeName -with exceptiononstop=true $appVerifierAdditionalProperties.Split()
+            & $appverifPath -enable $appVerifierEnable.Split() -for $exeName -with exceptiononstop=true $appVerifierAdditionalProperties.Split()
         }
     }
 }
 else
 {
     Write-Output "Disabling all appverifier settings"
-    & $resolvedAppverifPath -disable * -for *
+    & $appverifPath -disable * -for *
 }

--- a/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
+++ b/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
@@ -24,6 +24,19 @@
   .PARAMETER binaryNameSuffix
   Suffix for binary names of tests. E.g. if ctest returns some test names like foo, bar, and the binaries are foo_x.exe and bar_x.exe then this should be "_x.exe"
 
+  .PARAMETER appverifPath
+  Optional explicit path to appverif.exe. When omitted, the script falls back (in order) to the
+  APPVERIF_PATH env var, the ADO-injected APPVERIFPATH env var (from the pipeline variable
+  emitted by discover_native_tools.yml), and finally the system PATH. If none resolve to an
+  existing file the script logs a warning and exits 0 (preserves existing skip-when-missing
+  behavior on build pools that do not have AppVerifier installed, e.g. legacy ARM64 pools).
+
+  .PARAMETER ctestPath
+  Optional explicit path to ctest.exe (used in the -on path to enumerate tests). When omitted,
+  the script falls back to the ADO-injected CTESTPATH env var (from discover_native_tools.yml)
+  and finally to a hardcoded VS 2022 Enterprise location. If ctest cannot be found in -on mode
+  the script fails loudly so the AppVerifier gate cannot silently enable zero binaries.
+
   .INPUTS
   None. You cannot pipe objects to appverifier_ctest_tests_helper.ps1.
 
@@ -44,44 +57,70 @@ param(
     [Parameter()][string]$appVerifierAdditionalProperties = "",
     [Parameter()][string]$ctestArgs = "",
     [Parameter()][string]$binaryNameSuffix,
-    # Path to appverif.exe. Normally set by discover_native_tools.yml as the
-    # $(appverifPath) pipeline variable. If empty / unresolved / pointing at a
-    # non-existent file, the script probes PATH and known install locations as a
-    # fallback so it remains usable when invoked outside the discover-tools flow.
-    [Parameter()][string]$appverifPath = ""
+    [Parameter()][string]$appverifPath = "",
+    [Parameter()][string]$ctestPath = ""
 )
 
-# Resolve appverif.exe location: caller-provided path > PATH > known install locations.
-# Some agent images install Application Verifier outside of PATH (the standalone
-# installer drops it under "Program Files (x86)\Application Verifier" rather than
-# System32), so PATH alone is not sufficient.
-$appverifExe = $null
-if ($appverifPath -and (Test-Path $appverifPath)) {
-    $appverifExe = $appverifPath
-} else {
-    $appverifFromPath = Get-Command appverif.exe -ErrorAction SilentlyContinue
-    if ($appverifFromPath) {
-        $appverifExe = $appverifFromPath.Source
-    } else {
-        $candidates = @(
-            (Join-Path $env:windir 'System32\appverif.exe'),
-            (Join-Path ${env:ProgramFiles(x86)} 'Application Verifier\appverif.exe'),
-            (Join-Path $env:ProgramFiles 'Application Verifier\appverif.exe')
-        ) | Where-Object { $_ -and (Test-Path $_) }
-        if ($candidates.Count -gt 0) { $appverifExe = $candidates[0] }
-    }
+# Treat unresolved ADO macro literals (e.g. "$(appverifPath)" passed when the pipeline
+# variable was never set) and empty/whitespace strings as "not provided".
+function Resolve-OptionalPath
+{
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return $null }
+    if ($Value -match '^\$\(.+\)$') { return $null }
+    return $Value
 }
 
-if (-not $appverifExe) {
-    Write-Output "Application Verifier (appverif.exe) not found via PATH or known install locations. Skipping."
+# Resolve appverif.exe in priority order:
+#   1. -appverifPath parameter (passed by run_ctests_with_appverifier.yml /
+#      disable_appverifier.yml from the $(appverifPath) discovered by discover_native_tools.yml)
+#   2. APPVERIF_PATH env var (manual override)
+#   3. APPVERIFPATH env var (ADO-injected from pipeline variable 'appverifPath')
+#   4. Get-Command appverif.exe (PATH lookup; legacy build pools)
+$resolvedAppverifPath = Resolve-OptionalPath $appverifPath
+if (-not $resolvedAppverifPath) { $resolvedAppverifPath = Resolve-OptionalPath $env:APPVERIF_PATH }
+if (-not $resolvedAppverifPath) { $resolvedAppverifPath = Resolve-OptionalPath $env:APPVERIFPATH }
+if (-not $resolvedAppverifPath)
+{
+    $appverifCmd = Get-Command appverif.exe -ErrorAction SilentlyContinue
+    if ($appverifCmd) { $resolvedAppverifPath = $appverifCmd.Source }
+}
+if ($resolvedAppverifPath -and -not (Test-Path $resolvedAppverifPath))
+{
+    Write-Host "##vso[task.logissue type=warning]Resolved AppVerifier path '$resolvedAppverifPath' does not exist; ignoring."
+    $resolvedAppverifPath = $null
+}
+
+if (-not $resolvedAppverifPath) {
+    # Surface as an ADO warning so the build summary makes the silent skip visible.
+    Write-Host "##vso[task.logissue type=warning]Application Verifier (appverif.exe) is not available on this machine. AppVerifier steps will be skipped."
+    Write-Output "Application Verifier (appverif) is not installed on this machine. Skipping."
     exit 0
 }
-
-Write-Output "Using Application Verifier at: $appverifExe"
+Write-Output "Using Application Verifier at: $resolvedAppverifPath"
 
 if ($on)
 {
-    $allTests = & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe" -N $ctestArgs.Split()
+    # Resolve ctest.exe in priority order:
+    #   1. -ctestPath parameter (passed from $(ctestPath) discovered by discover_native_tools.yml)
+    #   2. CTESTPATH env var (ADO-injected from pipeline variable 'ctestPath')
+    #   3. Hardcoded VS 2022 Enterprise path (legacy fallback)
+    $resolvedCtestPath = Resolve-OptionalPath $ctestPath
+    if (-not $resolvedCtestPath) { $resolvedCtestPath = Resolve-OptionalPath $env:CTESTPATH }
+    if (-not $resolvedCtestPath)
+    {
+        $resolvedCtestPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\ctest.exe"
+    }
+    if (-not (Test-Path $resolvedCtestPath))
+    {
+        # In -on mode this MUST fail loudly: silently enumerating zero tests would leave the
+        # AppVerifier gate green while no binaries were actually instrumented.
+        Write-Host "##vso[task.logissue type=error]ctest.exe not found at '$resolvedCtestPath'. Cannot enumerate tests for AppVerifier instrumentation."
+        exit 1
+    }
+    Write-Output "Using CTest at: $resolvedCtestPath"
+
+    $allTests = & $resolvedCtestPath -N $ctestArgs.Split()
     $testsArray = $allTests.Split([Environment]::NewLine,[Stringsplitoptions]::RemoveEmptyEntries).trim()
 
     foreach ($t in $testsArray)
@@ -92,16 +131,13 @@ if ($on)
         {
             $testName = ($t -split ":")[1].Trim()
             $exeName = "$($testName)$($binaryNameSuffix)"
-            if ($on)
-            {
-                Write-Output "Enabling appverifier for $exeName"
-                & $appverifExe -enable $appVerifierEnable.Split() -for $exeName -with exceptiononstop=true $appVerifierAdditionalProperties.Split()
-            }
+            Write-Output "Enabling appverifier for $exeName"
+            & $resolvedAppverifPath -enable $appVerifierEnable.Split() -for $exeName -with exceptiononstop=true $appVerifierAdditionalProperties.Split()
         }
     }
 }
 else
 {
     Write-Output "Disabling all appverifier settings"
-    & $appverifExe -disable * -for *
+    & $resolvedAppverifPath -disable * -for *
 }

--- a/pipeline_templates/tasks/README.md
+++ b/pipeline_templates/tasks/README.md
@@ -19,7 +19,9 @@ All wrappers require the `discover_native_tools.yml` template to be called first
 - `$(cmakePath)` - cmake.exe from the VS installation
 - `$(ctestPath)` - ctest.exe from the VS installation
 - `$(msbuildPath)` - MSBuild.exe (architecture-specific)
+- `$(dumpbinPath)` - dumpbin.exe (architecture-specific)
 - `$(vstestPath)` - vstest.console.exe (architecture-specific)
+- `$(appverifPath)` - appverif.exe (empty string if not installed; consumed by `run_ctests_with_appverifier.yml` and `disable_appverifier.yml`)
 - `$(cmakeGenerator)` - CMake generator string (e.g., "Visual Studio 18 2026")
 - `$(cmakeArch)` - CMake architecture flag (x64, Win32, ARM64)
 - `$(targetPlatform)` - MSBuild platform (x64, Win32, ARM64)


### PR DESCRIPTION
Replace the legacy `run_arm64_tests` / `is_optional` / `skip_tests` parameters in build_all_flavors.yml and build_and_run_tests.yml with a single MAX_STAGE knob (BUILD / UNIT_TESTS / ALL, default UNIT_TESTS) that matches the convention already in use by EBS / ELS / GEO. After consumers bump their deps/c-build-tools pin, ARM64 legs symmetrically run unit tests (CTest, VSTest, AppVerifier when configured) and are blocking.

Changes:

- build_all_flavors.yml
  - Add MAX_STAGE parameter (string enum, default UNIT_TESTS).
  - Delete run_arm64_tests parameter and all references.
  - Stop forcing is_optional=true and skip_tests=true on ARM64.
  - Pipe MAX_STAGE down to build_and_run_tests.yml.
  - AppVerifier exclusion: skip APP_VERIFIER=ON whenever MAX_STAGE=BUILD (no point building an AppVerifier flavor that won't run tests).

- build_and_run_tests.yml
  - Add MAX_STAGE parameter; remove is_optional and skip_tests.
  - Test-execution gating becomes a positive match on UNIT_TESTS / ALL.
  - Drop the job-level continueOnError and the per-task ARM64 continueOnError on the VSTest task.
  - Make /collect:"Code Coverage;Format=Xml" and the subsequent PublishCodeCoverageResults step conditional on ARCH_TYPE != ARM64. tasks/vstest.yml currently appends otherConsoleOptions verbatim and does not honor its own codeCoverageEnabled parameter, so without this guard ARM64 VSTest would request a coverage collector that is not validated on the ARM64 build pools. Pre-existing bug exposed by enabling ARM64 VSTest; full wrapper cleanup is a follow-up.