### PR TITLE
Add retry to NuGet setup tasks for node24 task-host libuv crash

### DIFF
--- a/pipeline_templates/setup_nuget_tools.yml
+++ b/pipeline_templates/setup_nuget_tools.yml
@@ -2,8 +2,18 @@
 # this template file sets up NuGet tools to install the correct version consistently
 
 steps:
+# Retry to absorb the Node 24 task-host libuv assertion crash that occasionally
+# kills these wrappers on Windows ADO agents (Exit code 57005, faulting in
+# vss-agent\externals\node24\bin\node.exe). Tracked upstream as
+# https://github.com/nodejs/node/issues/56645 (open; pending fix in PR
+# https://github.com/nodejs/node/pull/61999) and in the agent as
+# https://github.com/microsoft/azure-pipelines-agent/issues/5498.
+# These tasks are idempotent setup -- retry is safe and any real failure will
+# still surface after the retries are exhausted.
 - task: NuGetAuthenticate@1
+  retryCountOnTaskFailure: 3
 
 - task: NuGetToolInstaller@1
   displayName: 'NuGet Install'
+  retryCountOnTaskFailure: 3
   continueOnError: true


### PR DESCRIPTION
## Summary

Add `retryCountOnTaskFailure: 3` to the two Node-handler setup tasks in this template (`NuGetAuthenticate@1` and `NuGetToolInstaller@1`).

## Why

Node 24 task-host wrappers on Windows ADO agents intermittently abort with **Exit code 57005** (Watson bucket `FAIL_FAST_FATAL_APP_EXIT_c0000409`, faulting in `vss-agent\externals\node24\bin\node.exe`). Symbolicated against the Node 24.13.0 PDB, the stack ends in:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)
file deps/uv/src/win/async.c, line 76
```

…which is libuv's `uv_async_send()` invoked from Node's `WorkerThreadsTaskRunner::DelayedTaskScheduler` shutdown path -- a lifecycle race between the task host's V8 platform tear-down and an in-flight async wakeup.

References:

- Upstream issue: nodejs/node#56645 (open since 2025-01-17)
- Upstream fix PR: nodejs/node#61999 (**not merged** as of writing)
- Agent issue: microsoft/azure-pipelines-agent#5498 (open, no fix)

The agent ships Node 24 (`externals/node24`) regardless of any pipeline `UseNode@1` step -- the task-host runtime is selected purely from each task's `target.runtimeVersion`. **The only currently available mitigation for consumers is to retry the affected wrapper invocations.**

In Azure-MessagingStore we measured ~9 `NuGetAuthenticate@1` / `Npm@1` / `UseNode@1` crashes across ~99 builds in the past 7 days (per-task failure rate ~9%). With `retryCountOnTaskFailure: 3` the residual rate drops to <0.01%.

## Why this is safe

- `NuGetAuthenticate@1` is idempotent (env-var setup + credential-provider probe).
- `NuGetToolInstaller@1` is idempotent (downloads + caches `nuget.exe`); already had `continueOnError: true`.
- Retry triggers on **any** non-zero exit, but for these setup tasks the only meaningful "real" failures will simply re-fail through all 3 attempts and surface as before.

## Rollback

Revert this commit once nodejs/node#61999 merges, Node ships it in a 24.x, the agent bumps `NODE24_VERSION` to that release, and the 1ES Hosted pool image rolls forward.