### PR TITLE
Define USE_HELGRIND and USE_DRD globally on Linux

### DIFF
--- a/build_functions/CMakeLists.txt
+++ b/build_functions/CMakeLists.txt
@@ -162,6 +162,16 @@ macro(set_default_build_options)
         add_definitions(-DUSE_VALGRIND)
     endif()
 
+    # Define USE_HELGRIND/USE_DRD globally (Linux only) so timing-sensitive tests can
+    # scale their constants when running under the corresponding tool.
+    if(${run_helgrind} AND (UNIX))
+        add_definitions(-DUSE_HELGRIND)
+    endif()
+
+    if(${run_drd} AND (UNIX))
+        add_definitions(-DUSE_DRD)
+    endif()
+
     if (WIN32)
         if (${use_segment_heap})
             if (CMAKE_GENERATOR MATCHES "Visual Studio")


### PR DESCRIPTION
## Summary
Define `USE_HELGRIND` and `USE_DRD` as separate global compile definitions on Linux, alongside the existing `USE_VALGRIND`.

## Motivation
Today `USE_VALGRIND` is set by `set_default_build_options()` whenever **any** of `run_valgrind`, `run_helgrind`, or `run_drd` is ON. This makes it impossible for a test to distinguish ""running under helgrind"" from ""running under valgrind/memcheck"" and adjust constants only where the tool's slowdown actually matters.

Concrete use case in zrpc: a heartbeat test with a 30s deadline passes under valgrind/memcheck but intermittently misses the deadline under helgrind because helgrind's instrumentation slowdown is significantly larger. With `USE_HELGRIND` defined separately, the test can do:

```c
#ifdef USE_HELGRIND
#define KEEP_ALIVE_DURATION_MS (150*1000)
#else
#define KEEP_ALIVE_DURATION_MS (30*1000)
#endif
```

without slowing down normal/valgrind/drd runs. This matches the existing pattern in `deps/c-pal/linux/CMakeLists.txt` which already defines `USE_HELGRIND` locally for c-pal sources, but it didn't propagate to consumers.

## Change
`build_functions/CMakeLists.txt`: After the existing `USE_VALGRIND` block, add two more conditional `add_definitions` calls for `USE_HELGRIND` and `USE_DRD`. Both gated on `UNIX` like the existing one.

## Backward compatibility
- `USE_VALGRIND` semantics unchanged (still ON when any tool is enabled).
- Existing consumers that only check `USE_VALGRIND` are unaffected.
- New defines only appear when their corresponding `run_*` option is ON, so existing behavior is preserved.

## Verification
Tested in zrpc with the c-build-tools submodule pointed at this branch:
- Default build (`run_helgrind=ON` default): `-DUSE_VALGRIND -DUSE_HELGRIND` both reach test compilation.
- `-Drun_helgrind:BOOL=OFF -Drun_drd:BOOL=OFF`: only `-DUSE_VALGRIND` is set.

---
Generated with assistance from GitHub Copilot CLI.
Session ID: `e229faf9-f4c3-4b04-b39f-36d92b38a1b2`