### PR TITLE
[MrBot] Bump diff from 5.2.0 to 5.2.2 in /srs_extension (CVE-2026-24001)

### DIFF
--- a/srs_extension/package-lock.json
+++ b/srs_extension/package-lock.json
@@ -649,9 +649,9 @@
             "dev": true
         },
         "node_modules/diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
@@ -2800,9 +2800,9 @@
             "dev": true
         },
         "diff": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-            "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+            "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
             "dev": true
         },
         "doctrine": {


### PR DESCRIPTION
## Summary
Bumps the transitive `diff` dependency (pulled in via `mocha`) in `/srs_extension` from **5.2.0 → 5.2.2** to remediate **CVE-2026-24001** (jsdiff `parsePatch` denial-of-service / ReDoS).

* CVE: [CVE-2026-24001](https://nvd.nist.gov/vuln/detail/CVE-2026-24001)
* Advisory: [GHSA-73rr-hh4g-fpgx](https://github.com/kpdecker/jsdiff/security/advisories/GHSA-73rr-hh4g-fpgx)
* Fix versions: 8.0.3, **5.2.2**, 4.0.4, 3.5.1

## Scope of risk in this repo
`diff` is a **dev-only transitive dependency** of `mocha` used to run the VS Code extension tests. It is not shipped in the published extension and is not used to parse untrusted patches.

## Verification
```
cd srs_extension
npm update diff --package-lock-only      # only lock-file change
npm ci                                   # installs cleanly
npm ls diff
# azure-req-doc-ext@0.0.10 ...\srs_extension
# \-- mocha@11.1.0
#   \-- diff@5.2.2
```

Lock file diff is minimal — only the two `diff` entries (the `node_modules/diff` lockfileVersion-2 entry and the legacy compat `diff` entry) had their `version`, `resolved` URL, and `integrity` updated to 5.2.2.

## Tracking
Addresses CG-generated work item [37706567](https://msazure.visualstudio.com/One/_workitems/edit/37706567) (CVE-2026-24001 in diff). The Azure-MessagingStore lock files (the originally-flagged 4.0.2 instances) were already updated to 4.0.4 upstream, so this PR closes out the remaining 5.x exposure for the same CVE.

Per repo convention: [MrBot] prefix indicates a Copilot-authored change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>