### PR TITLE
Clean up discover_native_tools output and report agent version/arch

### DIFF
--- a/pipeline_templates/discover_native_tools.yml
+++ b/pipeline_templates/discover_native_tools.yml
@@ -5,10 +5,14 @@
 # This template solves the ARM64 agent emulation problem by explicitly finding
 # and using native ARM64 tools instead of relying on the (broken) agent environment.
 #
+# It also prints the Azure Pipelines agent version and architecture up front, since
+# agent emulation (an x86 agent process running on an ARM64 host) is the root cause
+# this template works around.
+#
 # Output Variables:
 #   $(vsPath)       - Visual Studio installation path
 #   $(cmakePath)    - Path to cmake.exe
-#   $(ctestPath)    - Path to ctest.exe  
+#   $(ctestPath)    - Path to ctest.exe
 #   $(msbuildPath)  - Path to MSBuild.exe (architecture-specific)
 #   $(dumpbinPath)  - Path to dumpbin.exe (architecture-specific)
 #   $(vstestPath)   - Path to vstest.console.exe (architecture-specific)
@@ -42,25 +46,81 @@ steps:
     inputs:
       targetType: 'inline'
       script: |
+        $ErrorActionPreference = 'Stop'
         $arch = "${{ parameters.architecture }}"
-        Write-Host "============================================================"
-        Write-Host "DISCOVERING NATIVE BUILD TOOLS FOR $arch"
-        Write-Host "============================================================"
-        Write-Host ""
-        
-        # Map architecture to CMake arch, target platform, and MSBuild host folder
+
+        function Write-Section {
+            param([string]$Title)
+            Write-Host ""
+            Write-Host "===== $Title ====="
+        }
+
+        # Reads the machine type out of a PE header so we can report each tool's architecture.
+        function Get-PEArchitecture {
+            param([string]$FilePath)
+            if (-not $FilePath -or -not (Test-Path $FilePath)) { return $null }
+            try {
+                $stream = [System.IO.File]::OpenRead($FilePath)
+                $reader = New-Object System.IO.BinaryReader($stream)
+                $stream.Seek(0x3C, [System.IO.SeekOrigin]::Begin) | Out-Null
+                $peOffset = $reader.ReadInt32()
+                $stream.Seek($peOffset + 4, [System.IO.SeekOrigin]::Begin) | Out-Null
+                $machine = $reader.ReadUInt16()
+                $reader.Close()
+                $stream.Close()
+                switch ($machine) {
+                    0x014C { return "x86" }
+                    0x8664 { return "x64" }
+                    0xAA64 { return "ARM64" }
+                    default { return "Unknown (0x$($machine.ToString('X4')))" }
+                }
+            } catch {
+                return "Error reading PE header"
+            }
+        }
+
+        Write-Section "DISCOVERING NATIVE BUILD TOOLS FOR $arch"
+
+        # ----------------------------------------------------------------
+        # Azure Pipelines agent
+        # ----------------------------------------------------------------
+        # Agent.* variables describe the agent the job is running on. ProcessArchitecture
+        # reveals whether PowerShell itself is emulated (e.g. an x86 process on an ARM64
+        # host), which is precisely the condition this template exists to work around.
+        Write-Section "AZURE PIPELINES AGENT"
+        function Coalesce { param([string]$Value) if ([string]::IsNullOrEmpty($Value)) { "(unknown)" } else { $Value } }
+        $agentName    = Coalesce $env:AGENT_NAME
+        $agentVersion = Coalesce $env:AGENT_VERSION
+        $agentOS      = Coalesce $env:AGENT_OS
+        $agentOSArch  = Coalesce $env:AGENT_OSARCHITECTURE
+        $processArch  = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture
+        $osArch       = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+        Write-Host ("  Name:               {0}" -f $agentName)
+        Write-Host ("  Version:            {0}" -f $agentVersion)
+        Write-Host ("  OS:                 {0}" -f $agentOS)
+        Write-Host ("  OS architecture:    {0}" -f $agentOSArch)
+        Write-Host ("  Task process arch:  {0}" -f $processArch)
+        Write-Host ("  Host OS arch:       {0}" -f $osArch)
+        if ("$processArch" -ne "$osArch") {
+            Write-Host "##[warning]PowerShell task process architecture ($processArch) differs from host OS architecture ($osArch); the agent is running under emulation."
+        }
+
+        # ----------------------------------------------------------------
+        # Architecture mapping
+        # ----------------------------------------------------------------
+        Write-Section "ARCHITECTURE MAPPING"
         switch ($arch) {
-            'x64'   { 
+            'x64'   {
                 $cmakeArch = 'x64'
                 $targetPlatform = 'x64'
                 $msbuildHost = 'amd64'
             }
-            'x86'   { 
+            'x86'   {
                 $cmakeArch = 'Win32'
                 $targetPlatform = 'Win32'
                 $msbuildHost = 'amd64'  # Use x64 MSBuild even for x86 targets
             }
-            'ARM64' { 
+            'ARM64' {
                 $cmakeArch = 'ARM64'
                 $targetPlatform = 'ARM64'
                 $msbuildHost = 'arm64'
@@ -70,89 +130,83 @@ steps:
                 exit 1
             }
         }
-        
-        Write-Host "Architecture mapping:"
-        Write-Host "  CMake -A flag:     $cmakeArch"
-        Write-Host "  MSBuild Platform:  $targetPlatform"
-        Write-Host "  MSBuild Host:      $msbuildHost"
-        Write-Host ""
-        
-        # Find Visual Studio using vswhere
+        Write-Host ("  CMake -A flag:     {0}" -f $cmakeArch)
+        Write-Host ("  MSBuild Platform:  {0}" -f $targetPlatform)
+        Write-Host ("  MSBuild Host:      {0}" -f $msbuildHost)
+        Write-Host "##vso[task.setvariable variable=cmakeArch]$cmakeArch"
+        Write-Host "##vso[task.setvariable variable=targetPlatform]$targetPlatform"
+
+        # ----------------------------------------------------------------
+        # Visual Studio
+        # ----------------------------------------------------------------
+        Write-Section "VISUAL STUDIO"
         $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
         if (-not (Test-Path $vswhere)) {
             Write-Error "vswhere.exe not found at $vswhere"
             exit 1
         }
-        
+
         $vsPath = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
         if (-not $vsPath) {
             Write-Error "Could not find Visual Studio installation"
             exit 1
         }
-        Write-Host "Visual Studio found at: $vsPath"
-        Write-Host "##vso[task.setvariable variable=vsPath]$vsPath"
-        
-        # Get VS version to determine CMake generator
         $vsVersion = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationVersion
         $vsMajor = [int]($vsVersion -split '\.')[0]
-        Write-Host "Visual Studio version: $vsVersion (major: $vsMajor)"
-        
-        # Map VS major version to CMake generator
         $cmakeGenerator = switch ($vsMajor) {
             18 { "Visual Studio 18 2026" }
             17 { "Visual Studio 17 2022" }
             16 { "Visual Studio 16 2019" }
             default { "Visual Studio $vsMajor" }
         }
-        Write-Host "CMake generator: $cmakeGenerator"
+        Write-Host ("  Path:             {0}" -f $vsPath)
+        Write-Host ("  Version:          {0} (major {1})" -f $vsVersion, $vsMajor)
+        Write-Host ("  CMake generator:  {0}" -f $cmakeGenerator)
+        Write-Host "##vso[task.setvariable variable=vsPath]$vsPath"
         Write-Host "##vso[task.setvariable variable=cmakeGenerator]$cmakeGenerator"
-        Write-Host ""
-        
-        # Find CMake bundled with Visual Studio
+
+        # ----------------------------------------------------------------
+        # Tool discovery
+        # ----------------------------------------------------------------
+        Write-Section "TOOL DISCOVERY"
+
+        # CMake / CTest bundled with Visual Studio
         $cmakeBinDir = Join-Path $vsPath "Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin"
         $cmakePath = Join-Path $cmakeBinDir "cmake.exe"
         $ctestPath = Join-Path $cmakeBinDir "ctest.exe"
-        
         if (-not (Test-Path $cmakePath)) {
             Write-Error "CMake not found at $cmakePath"
             exit 1
         }
-        
-        Write-Host "CMake: $cmakePath"
-        Write-Host "CTest: $ctestPath"
+        Write-Host "  cmake.exe   found"
+        if (Test-Path $ctestPath) {
+            Write-Host "  ctest.exe   found"
+        } else {
+            Write-Host "##[warning]ctest.exe not found at $ctestPath"
+        }
         Write-Host "##vso[task.setvariable variable=cmakePath]$cmakePath"
         Write-Host "##vso[task.setvariable variable=ctestPath]$ctestPath"
-        Write-Host ""
-        
-        # Find MSBuild for the correct host architecture
-        # For ARM64, we need MSBuild\Current\Bin\arm64\MSBuild.exe to get native compilation
+
+        # MSBuild for the correct host architecture.
+        # For ARM64 we need MSBuild\Current\Bin\arm64\MSBuild.exe to get native compilation.
         $msbuildPath = Join-Path $vsPath "MSBuild\Current\Bin\$msbuildHost\MSBuild.exe"
-        
         if (-not (Test-Path $msbuildPath)) {
-            # Fallback to default MSBuild location
             $msbuildPath = Join-Path $vsPath "MSBuild\Current\Bin\MSBuild.exe"
             Write-Host "##[warning]Architecture-specific MSBuild not found, falling back to: $msbuildPath"
         }
-        
         if (-not (Test-Path $msbuildPath)) {
             Write-Error "MSBuild not found"
             exit 1
         }
-        
-        Write-Host "MSBuild: $msbuildPath"
+        Write-Host "  MSBuild.exe found"
         Write-Host "##vso[task.setvariable variable=msbuildPath]$msbuildPath"
-        Write-Host ""
-        
-        # Find dumpbin for the correct host architecture
-        # dumpbin is in the VC tools bin directory alongside cl.exe
+
+        # dumpbin lives in the VC tools bin directory alongside cl.exe.
         $vcToolsDir = Join-Path $vsPath "VC\Tools\MSVC"
         $dumpbinPath = $null
-        
         if (Test-Path $vcToolsDir) {
-            # Get the latest MSVC version
             $msvcVersions = Get-ChildItem $vcToolsDir -Directory | Sort-Object Name -Descending
             foreach ($msvcVersion in $msvcVersions) {
-                # Construct the architecture-specific path
                 if ($arch -eq "ARM64") {
                     $hostTarget = "Hostarm64\arm64"
                 } elseif ($arch -eq "x86") {
@@ -160,13 +214,13 @@ steps:
                 } else {
                     $hostTarget = "Hostx64\x64"
                 }
-                
+
                 $candidatePath = Join-Path $msvcVersion.FullName "bin\$hostTarget\dumpbin.exe"
                 if (Test-Path $candidatePath) {
                     $dumpbinPath = $candidatePath
                     break
                 }
-                
+
                 # Fallback to x64 if arch-specific not found
                 $candidatePath = Join-Path $msvcVersion.FullName "bin\Hostx64\x64\dumpbin.exe"
                 if (Test-Path $candidatePath) {
@@ -176,19 +230,17 @@ steps:
                 }
             }
         }
-        
         if ($dumpbinPath -and (Test-Path $dumpbinPath)) {
-            Write-Host "dumpbin: $dumpbinPath"
+            Write-Host "  dumpbin.exe found"
             Write-Host "##vso[task.setvariable variable=dumpbinPath]$dumpbinPath"
-            # Also set as environment variable for subprocesses (like ctest)
+            # Also expose to subprocesses (like ctest) via an environment variable.
             Write-Host "##vso[task.setvariable variable=DUMPBIN_PATH]$dumpbinPath"
             [Environment]::SetEnvironmentVariable("DUMPBIN_PATH", $dumpbinPath, "Process")
         } else {
             Write-Host "##[warning]dumpbin not found - reals_check may fail"
         }
-        Write-Host ""
 
-        # Find Application Verifier (appverif.exe).
+        # Application Verifier (appverif.exe).
         # Detection is mandatory: if appverif.exe cannot be located, this discovery
         # step aborts the job. Every consumer of c-build-tools is expected to run on
         # build pools that have AppVerifier installed; a missing appverif is treated
@@ -242,17 +294,12 @@ steps:
             Write-Host "##[error]appverif.exe is required on every build pool. Aborting native tools discovery."
             exit 1
         }
-
-        Write-Host "appverif: $appverifPath"
+        Write-Host "  appverif.exe found"
         Write-Host "##vso[task.setvariable variable=appverifPath]$appverifPath"
-        Write-Host ""
 
-        # Find vstest.console.exe
-        # Path pattern: <vsPath>\Common7\IDE\CommonExtensions\<Microsoft|Platform>\TestPlatform
+        # vstest.console.exe under Common7\IDE\CommonExtensions\<Microsoft|Platform>\TestPlatform
         $vstestPath = $null
         $vstestExeName = "vstest.console.exe"
-        
-        # Check known locations under Common7\IDE\CommonExtensions
         $commonExtensions = Join-Path $vsPath "Common7\IDE\CommonExtensions"
         $searchPaths = @(
             (Join-Path $commonExtensions "Microsoft\TestPlatform"),
@@ -260,20 +307,15 @@ steps:
             (Join-Path $commonExtensions "Microsoft\TestWindow"),
             (Join-Path $commonExtensions "Platform\TestWindow")
         )
-        
         foreach ($searchPath in $searchPaths) {
             $candidatePath = Join-Path $searchPath $vstestExeName
-            Write-Host "Checking: $candidatePath"
             if (Test-Path $candidatePath) {
                 $vstestPath = $candidatePath
-                Write-Host "Found vstest at: $vstestPath"
                 break
             }
         }
-        
         if (-not $vstestPath) {
             # Fallback: use vswhere -find
-            Write-Host "vstest not found in known locations, trying vswhere -find..."
             $vstestCandidates = & $vswhere -latest -products * -requires Microsoft.VisualStudio.TestTools.TestPlatform -find "**\$vstestExeName" 2>$null
             if ($vstestCandidates) {
                 if ($vstestCandidates -is [array]) {
@@ -283,106 +325,70 @@ steps:
                 }
             }
         }
-        
         if ($vstestPath -and (Test-Path $vstestPath)) {
-            Write-Host "vstest: $vstestPath"
+            Write-Host "  vstest.console.exe found"
             Write-Host "##vso[task.setvariable variable=vstestPath]$vstestPath"
         } else {
             Write-Host "##[warning]$vstestExeName not found"
         }
-        Write-Host ""
 
-        # Set architecture variables for use in build commands
-        Write-Host "##vso[task.setvariable variable=cmakeArch]$cmakeArch"
-        Write-Host "##vso[task.setvariable variable=targetPlatform]$targetPlatform"
-        Write-Host ""
-        
-        # ============================================================
-        # ARCHITECTURE VERIFICATION
-        # Verify all detected executables match the expected architecture
-        # ============================================================
-        Write-Host "============================================================"
-        Write-Host "VERIFYING TOOL ARCHITECTURES"
-        Write-Host "============================================================"
-        Write-Host ""
-        
-        # Helper function to get PE architecture from PE header
-        function Get-PEArchitecture {
-            param([string]$FilePath)
-            if (-not (Test-Path $FilePath)) { return $null }
-            try {
-                $stream = [System.IO.File]::OpenRead($FilePath)
-                $reader = New-Object System.IO.BinaryReader($stream)
-                $stream.Seek(0x3C, [System.IO.SeekOrigin]::Begin) | Out-Null
-                $peOffset = $reader.ReadInt32()
-                $stream.Seek($peOffset + 4, [System.IO.SeekOrigin]::Begin) | Out-Null
-                $machine = $reader.ReadUInt16()
-                $reader.Close()
-                $stream.Close()
-                switch ($machine) {
-                    0x014C { return "x86" }
-                    0x8664 { return "x64" }
-                    0xAA64 { return "ARM64" }
-                    default { return "Unknown (0x$($machine.ToString('X4')))" }
-                }
-            } catch {
-                return "Error reading PE header"
-            }
-        }
-        
-        # Expected architecture based on target
+        # ----------------------------------------------------------------
+        # Summary + architecture verification
+        # ----------------------------------------------------------------
+        # One table reports every discovered tool, its PE architecture, and whether it
+        # matches the expected target architecture. appverif.exe is listed for reference
+        # but its architecture is not enforced (status "n/a").
+        Write-Section "DISCOVERED TOOLS"
         $expectedArch = switch ($arch) {
             'x64'   { 'x64' }
             'x86'   { 'x86' }
             'ARM64' { 'ARM64' }
         }
-        
+        $tools = @(
+            [pscustomobject]@{ Name = 'cmake.exe';          Path = $cmakePath;    Verify = $true  }
+            [pscustomobject]@{ Name = 'ctest.exe';          Path = $ctestPath;    Verify = $true  }
+            [pscustomobject]@{ Name = 'MSBuild.exe';        Path = $msbuildPath;  Verify = $true  }
+            [pscustomobject]@{ Name = 'dumpbin.exe';        Path = $dumpbinPath;  Verify = $true  }
+            [pscustomobject]@{ Name = 'vstest.console.exe'; Path = $vstestPath;   Verify = $true  }
+            [pscustomobject]@{ Name = 'appverif.exe';       Path = $appverifPath; Verify = $false }
+        )
+        Write-Host ("  {0,-20} {1,-10} {2,-10} {3}" -f "Tool", "Arch", "Status", "Path")
+        Write-Host ("  {0,-20} {1,-10} {2,-10} {3}" -f "----", "----", "------", "----")
         $archMismatches = @()
-        $toolsToVerify = @{}
-        if ($cmakePath) { $toolsToVerify['cmake.exe'] = $cmakePath }
-        if ($ctestPath) { $toolsToVerify['ctest.exe'] = $ctestPath }
-        if ($msbuildPath) { $toolsToVerify['MSBuild.exe'] = $msbuildPath }
-        if ($dumpbinPath) { $toolsToVerify['dumpbin.exe'] = $dumpbinPath }
-        if ($vstestPath) { $toolsToVerify['vstest.console.exe'] = $vstestPath }
-        # appverif.exe is intentionally NOT verified here - it is a configuration tool
-        # whose own PE architecture is not required to match the target architecture.
-        
-        foreach ($tool in $toolsToVerify.GetEnumerator()) {
-            $toolArch = Get-PEArchitecture -FilePath $tool.Value
-            $status = if ($toolArch -eq $expectedArch -or ($expectedArch -eq 'x86' -and $toolArch -eq 'x64')) { "OK" } else { "MISMATCH" }
-            
-            Write-Host "$($tool.Key): $toolArch (expected: $expectedArch) [$status]"
-            Write-Host "  Path: $($tool.Value)"
-            
-            if ($status -eq "MISMATCH" -and $expectedArch -eq "ARM64") {
-                $archMismatches += "$($tool.Key) is $toolArch, expected $expectedArch"
+        foreach ($t in $tools) {
+            if (-not $t.Path -or -not (Test-Path $t.Path)) {
+                Write-Host ("  {0,-20} {1,-10} {2,-10} {3}" -f $t.Name, "-", "missing", "(not found)")
+                continue
             }
+            $toolArch = Get-PEArchitecture -FilePath $t.Path
+            if ($t.Verify) {
+                $ok = ($toolArch -eq $expectedArch) -or ($expectedArch -eq 'x86' -and $toolArch -eq 'x64')
+                $status = if ($ok) { "OK" } else { "MISMATCH" }
+                if (-not $ok -and $expectedArch -eq 'ARM64') {
+                    $archMismatches += "$($t.Name) is $toolArch, expected $expectedArch"
+                }
+            } else {
+                $status = "n/a"
+            }
+            Write-Host ("  {0,-20} {1,-10} {2,-10} {3}" -f $t.Name, $toolArch, $status, $t.Path)
         }
-        Write-Host ""
-        
+
         if ($archMismatches.Count -gt 0) {
             Write-Host "##[warning]Architecture mismatches detected for ARM64 build:"
             foreach ($mismatch in $archMismatches) {
                 Write-Host "##[warning]  - $mismatch"
             }
             Write-Host "##[warning]Some tools may run under emulation, which can affect performance."
-            Write-Host ""
-        } else {
-            Write-Host "All tools verified to have correct architecture."
-            Write-Host ""
         }
-        
-        Write-Host "============================================================"
-        Write-Host "TOOL DISCOVERY COMPLETE"
-        Write-Host "============================================================"
-        Write-Host ""
-        Write-Host "Use these variables in subsequent steps:"
+
+        # ----------------------------------------------------------------
+        # Usage
+        # ----------------------------------------------------------------
+        Write-Section "USAGE"
         Write-Host '  CMake:    "$(cmakePath)" -S . -B build -G "$(cmakeGenerator)" -A $(cmakeArch)'
         Write-Host '  MSBuild:  "$(msbuildPath)" solution.sln /p:Platform=$(targetPlatform)'
         Write-Host '  CTest:    "$(ctestPath)" -C Debug --output-on-failure'
         Write-Host '  dumpbin:  "$(dumpbinPath)" /ALL mylib.lib'
         Write-Host '  vstest:   "$(vstestPath)" test.dll /Platform:$(targetPlatform)'
         Write-Host '  appverif: "$(appverifPath)" -enable Heaps -for foo.exe'
-        Write-Host ""
-        Write-Host "Environment variable DUMPBIN_PATH is also set for subprocesses (e.g., ctest)"
-        Write-Host ""
+        Write-Host "  (environment variable DUMPBIN_PATH is also set for subprocesses such as ctest)"


### PR DESCRIPTION
Restructure the Discover Native Tools template output into consistent sections and a single DISCOVERED TOOLS summary table, replacing the previous scattered logging and duplicated discovery/verification passes.

Add an AZURE PIPELINES AGENT section that prints the agent name, version, OS, and OS architecture, plus the PowerShell task process architecture and host OS architecture, warning when they differ (emulation).

All existing pipeline output variables and the mandatory appverif abort behavior are preserved.