### PR TITLE
Add pipeline hang watchdog for automatic test hang detection and dump capture

### DIFF
--- a/pipeline_templates/build_all_flavors.yml
+++ b/pipeline_templates/build_all_flavors.yml
@@ -119,7 +119,7 @@ parameters:
     default: '_exe_'
   - name: hang_dump_threshold_sec
     type: number
-    default: 1380
+    default: 1200
 
 jobs:
 # Run repo validation and traceability once (not per-flavor)

--- a/pipeline_templates/build_all_flavors.yml
+++ b/pipeline_templates/build_all_flavors.yml
@@ -109,6 +109,18 @@ parameters:
     type: boolean
     default: false
 
+  # Hang watchdog: wraps CTest with a background process that captures
+  # full-memory dumps of test exes approaching their per-test timeout.
+  - name: enable_hang_watchdog
+    type: boolean
+    default: true
+  - name: hang_watchdog_name_pattern
+    type: string
+    default: '_exe_'
+  - name: hang_dump_threshold_sec
+    type: number
+    default: 1380
+
 jobs:
 # Run repo validation and traceability once (not per-flavor)
 - ${{ if not(parameters.skip_repo_validation) }}:
@@ -145,6 +157,9 @@ jobs:
                 failOnMinTestsNotRun: ${{ parameters.failOnMinTestsNotRun }}
                 setup_nuget: ${{ parameters.setup_nuget }}
                 publish_artifacts_on_success: ${{ parameters.publish_artifacts_on_success }}
+                enable_hang_watchdog: ${{ parameters.enable_hang_watchdog }}
+                hang_watchdog_name_pattern: ${{ parameters.hang_watchdog_name_pattern }}
+                hang_dump_threshold_sec: ${{ parameters.hang_dump_threshold_sec }}
                 # Per-architecture pool selection AND effective MAX_STAGE.
                 # ARM64 -> arm64_max_stage (default UNIT_TESTS; caller-settable so
                 # repos migrate ARM64 test depth one at a time). x64 -> ALL (run

--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -72,6 +72,17 @@ parameters:
   - name: publish_artifacts_on_success
     type: boolean
     default: false
+  # Hang watchdog: wraps CTest execution with a background process that captures
+  # full-memory dumps of test exes approaching their per-test timeout.
+  - name: enable_hang_watchdog
+    type: boolean
+    default: true
+  - name: hang_watchdog_name_pattern
+    type: string
+    default: '_exe_'
+  - name: hang_dump_threshold_sec
+    type: number
+    default: 1380
 
 jobs:
 - job: build_and_run_tests_${{ parameters.BUILD_SUFFIX }}
@@ -145,46 +156,55 @@ jobs:
               summaryFileLocation: '$(build.ArtifactStagingDirectory)/Test/VsTest/Results/${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}/*/*.xml'
               pathToSources: '$(Build.SourcesDirectory)'
 
-      # Use wrapper template for CTest - handles ARM64 native tools transparently
+      # CTest execution — when hang watchdog is enabled, wrap with watchdog for dump capture.
+      # When disabled, use the original tasks/ctest.yml template.
       - ${{ if eq(parameters.run_test_suite_without_ctest, '') }}:
-        - template: tasks/ctest.yml
-          parameters:
-            architecture: ${{ parameters.ARCH_TYPE }}
-            workingDirectory: '$(Build.BinariesDirectory)/c'
-            configuration: '${{ parameters.build_configuration }}'
-            outputJunit: 'ctest_results_${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}.xml'
-            # MAX_STAGE=UNIT_TESTS: skip non-unit-test categories on every architecture.
-            # Test names registered by build_test_artifacts (in c-testrunnerswitcher)
-            # follow the convention of containing _ut, _int, _perf, or _e2e in the name
-            # (typically as the trailing or middle token, e.g. foo_ut, foo_int_tests,
-            # logger_int_console_x). CMake's run_unittests / run_int_tests /
-            # run_perf_tests / run_e2e_tests options control registration; with the
-            # gate's default cmake_options every category gets registered, and ctest
-            # then runs them all. VSTest already filters to *_ut_*.dll via its
-            # discovery glob, but ctest does not.
-            #
-            # We exclude (rather than include) so projects whose tests do not follow
-            # the _ut suffix convention - notably c-build-tools' own validate_*_test
-            # and RUN_REALS_CHECK_TEST gates - still run instead of being filtered out
-            # and tripping --no-tests=error.
-            #
-            # The regex uses ($|_) after each category so it matches both trailing
-            # uses (foo_int) and middle uses (foo_int_tests, logger_int_console_x).
-            # Filter at run time so BUILD-stage semantics still hold (int/perf/e2e
-            # still compile - useful as a compile-only ratchet) while UNIT_TESTS
-            # strictly skips _int/_perf/_e2e and INT_TESTS skips only _perf/_e2e at
-            # run time. MAX_STAGE=ALL bypasses this filter.
-            #
-            # When the filter IS active (UNIT_TESTS or INT_TESTS), also disable
-            # --no-tests=error: repos that have only int/perf/e2e tests (e.g.
-            # macro-utils-c) legitimately match zero tests after the filter, and
-            # that is not a build error.
-            ${{ if eq(parameters.MAX_STAGE, 'UNIT_TESTS') }}:
-              excludeTests: '_int($|_)|_perf($|_)|_e2e($|_)'
-              noTestsError: false
-            ${{ if eq(parameters.MAX_STAGE, 'INT_TESTS') }}:
-              excludeTests: '_perf($|_)|_e2e($|_)'
-              noTestsError: false
+        - ${{ if parameters.enable_hang_watchdog }}:
+          # Watchdog-wrapped CTest: builds ctest arguments per MAX_STAGE filter
+          - ${{ if eq(parameters.MAX_STAGE, 'UNIT_TESTS') }}:
+            - template: run_with_hang_watchdog.yml
+              parameters:
+                repo_root: ${{ parameters.repo_root_override }}
+                display_name: 'CTest (${{ parameters.ARCH_TYPE }}) [watchdog]'
+                executable: '$(ctestPath)'
+                working_directory: '$(Build.BinariesDirectory)/c'
+                name_pattern: '${{ parameters.hang_watchdog_name_pattern }}'
+                dump_threshold_sec: ${{ parameters.hang_dump_threshold_sec }}
+                arguments: '-C ${{ parameters.build_configuration }} --output-on-failure --interactive-debug-mode 1 --output-junit ctest_results_${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}.xml -E "_int($|_)|_perf($|_)|_e2e($|_)"'
+          - ${{ if eq(parameters.MAX_STAGE, 'INT_TESTS') }}:
+            - template: run_with_hang_watchdog.yml
+              parameters:
+                repo_root: ${{ parameters.repo_root_override }}
+                display_name: 'CTest (${{ parameters.ARCH_TYPE }}) [watchdog]'
+                executable: '$(ctestPath)'
+                working_directory: '$(Build.BinariesDirectory)/c'
+                name_pattern: '${{ parameters.hang_watchdog_name_pattern }}'
+                dump_threshold_sec: ${{ parameters.hang_dump_threshold_sec }}
+                arguments: '-C ${{ parameters.build_configuration }} --output-on-failure --interactive-debug-mode 1 --output-junit ctest_results_${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}.xml -E "_perf($|_)|_e2e($|_)"'
+          - ${{ if eq(parameters.MAX_STAGE, 'ALL') }}:
+            - template: run_with_hang_watchdog.yml
+              parameters:
+                repo_root: ${{ parameters.repo_root_override }}
+                display_name: 'CTest (${{ parameters.ARCH_TYPE }}) [watchdog]'
+                executable: '$(ctestPath)'
+                working_directory: '$(Build.BinariesDirectory)/c'
+                name_pattern: '${{ parameters.hang_watchdog_name_pattern }}'
+                dump_threshold_sec: ${{ parameters.hang_dump_threshold_sec }}
+                arguments: '-C ${{ parameters.build_configuration }} --output-on-failure --interactive-debug-mode 1 --no-tests=error --output-junit ctest_results_${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}.xml'
+
+        - ${{ if not(parameters.enable_hang_watchdog) }}:
+          - template: tasks/ctest.yml
+            parameters:
+              architecture: ${{ parameters.ARCH_TYPE }}
+              workingDirectory: '$(Build.BinariesDirectory)/c'
+              configuration: '${{ parameters.build_configuration }}'
+              outputJunit: 'ctest_results_${{ parameters.build_configuration }}${{ parameters.BUILD_SUFFIX }}.xml'
+              ${{ if eq(parameters.MAX_STAGE, 'UNIT_TESTS') }}:
+                excludeTests: '_int($|_)|_perf($|_)|_e2e($|_)'
+                noTestsError: false
+              ${{ if eq(parameters.MAX_STAGE, 'INT_TESTS') }}:
+                excludeTests: '_perf($|_)|_e2e($|_)'
+                noTestsError: false
 
       - ${{ if eq(parameters.run_test_suite_without_ctest, '') }}:
         - task: PublishTestResults@2

--- a/pipeline_templates/build_and_run_tests.yml
+++ b/pipeline_templates/build_and_run_tests.yml
@@ -82,7 +82,7 @@ parameters:
     default: '_exe_'
   - name: hang_dump_threshold_sec
     type: number
-    default: 1380
+    default: 1200
 
 jobs:
 - job: build_and_run_tests_${{ parameters.BUILD_SUFFIX }}

--- a/pipeline_templates/build_teardown_steps.yml
+++ b/pipeline_templates/build_teardown_steps.yml
@@ -25,4 +25,13 @@ steps:
       parallel: true
     condition: failed()
 
+  # Publish hang watchdog dumps if any were captured
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish hang dumps'
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)/test_hang_dumps'
+      artifactName: 'test_hang_dumps_${{ parameters.artifact_name_suffix }}'
+      parallel: true
+    condition: and(always(), eq(variables['HangDumpsCaptured'], 'true'))
+
   - template : clean_ado_folders.yml

--- a/pipeline_templates/run_with_hang_watchdog.yml
+++ b/pipeline_templates/run_with_hang_watchdog.yml
@@ -1,0 +1,69 @@
+# Runs an arbitrary executable (ctest or a single test exe) alongside a watchdog process that
+# captures full-memory dumps of test processes which approach their per-test timeout.
+#
+# When a candidate process's age exceeds dump_threshold_sec the watchdog calls awdump
+# (preferred, available on gate machines via MonAgentCore install dir) or procdump
+# (fallback).
+#
+# All logic lives in pipeline_templates/scripts/run_with_hang_watchdog.ps1 so it can also be
+# run from a developer shell against a locally-built test exe.
+#
+# Dumps and hang_summary.txt are written to $(Build.ArtifactStagingDirectory)/test_hang_dumps,
+# which build_teardown_steps.yml publishes as the test_hang_dumps pipeline artifact on failure.
+#
+# The wrapper preserves the wrapped executable's exit code so failure semantics are unchanged.
+
+parameters:
+  - name: display_name
+    type: string
+  - name: executable
+    type: string
+  - name: arguments
+    type: string
+    default: ''
+  - name: working_directory
+    type: string
+  - name: dump_threshold_sec
+    type: number
+    default: 1380
+  - name: poll_interval_sec
+    type: number
+    default: 30
+  - name: name_pattern
+    type: string
+    default: '_exe_'
+  # When the wrapped executable IS the test exe (single-exe runner) set this true.
+  # When the wrapped executable is ctest (and the actual test exes are its children) leave it false.
+  - name: include_watched
+    type: boolean
+    default: false
+  # When true, the watchdog kills each candidate process after capturing its dump. Use this for
+  # single-exe runs so the wrapped exe exits promptly after the dump is taken -- otherwise the
+  # surrounding ADO job timeout can reap the task before the dump artifact gets published.
+  # Leave false under ctest (killing a child would skip remaining tests).
+  - name: kill_after_dump
+    type: boolean
+    default: false
+  - name: env
+    type: object
+    default: {}
+  - name: repo_root
+    default: $(Build.SourcesDirectory)/deps/c-build-tools
+
+steps:
+  - task: PowerShell@2
+    displayName: ${{ parameters.display_name }}
+    inputs:
+      targetType: filePath
+      filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/run_with_hang_watchdog.ps1'
+      arguments: >-
+        -Executable '${{ parameters.executable }}'
+        -Arguments '${{ parameters.arguments }}'
+        -WorkingDirectory '${{ parameters.working_directory }}'
+        -DumpThresholdSec ${{ parameters.dump_threshold_sec }}
+        -PollIntervalSec ${{ parameters.poll_interval_sec }}
+        -NamePattern '${{ parameters.name_pattern }}'
+        -IncludeWatched $${{ parameters.include_watched }}
+        -KillAfterDump $${{ parameters.kill_after_dump }}
+        -WatchdogScript '${{ parameters.repo_root }}/pipeline_templates/scripts/test_hang_watchdog.ps1'
+    env: ${{ parameters.env }}

--- a/pipeline_templates/run_with_hang_watchdog.yml
+++ b/pipeline_templates/run_with_hang_watchdog.yml
@@ -54,16 +54,17 @@ steps:
   - task: PowerShell@2
     displayName: ${{ parameters.display_name }}
     inputs:
-      targetType: filePath
-      filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/run_with_hang_watchdog.ps1'
-      arguments: >-
-        -Executable '${{ parameters.executable }}'
-        -Arguments '${{ parameters.arguments }}'
-        -WorkingDirectory '${{ parameters.working_directory }}'
-        -DumpThresholdSec ${{ parameters.dump_threshold_sec }}
-        -PollIntervalSec ${{ parameters.poll_interval_sec }}
-        -NamePattern '${{ parameters.name_pattern }}'
-        -IncludeWatched $${{ parameters.include_watched }}
-        -KillAfterDump $${{ parameters.kill_after_dump }}
-        -WatchdogScript '${{ parameters.repo_root }}/pipeline_templates/scripts/test_hang_watchdog.ps1'
+      targetType: inline
+      script: |
+        & '${{ parameters.repo_root }}/pipeline_templates/scripts/run_with_hang_watchdog.ps1' `
+          -Executable '${{ parameters.executable }}' `
+          -Arguments '${{ parameters.arguments }}' `
+          -WorkingDirectory '${{ parameters.working_directory }}' `
+          -DumpThresholdSec ${{ parameters.dump_threshold_sec }} `
+          -PollIntervalSec ${{ parameters.poll_interval_sec }} `
+          -NamePattern '${{ parameters.name_pattern }}' `
+          -IncludeWatched $${{ parameters.include_watched }} `
+          -KillAfterDump $${{ parameters.kill_after_dump }} `
+          -WatchdogScript '${{ parameters.repo_root }}/pipeline_templates/scripts/test_hang_watchdog.ps1'
+        exit $LASTEXITCODE
     env: ${{ parameters.env }}

--- a/pipeline_templates/run_with_hang_watchdog.yml
+++ b/pipeline_templates/run_with_hang_watchdog.yml
@@ -25,7 +25,7 @@ parameters:
     type: string
   - name: dump_threshold_sec
     type: number
-    default: 1380
+    default: 1200
   - name: poll_interval_sec
     type: number
     default: 30

--- a/pipeline_templates/scripts/run_with_hang_watchdog.ps1
+++ b/pipeline_templates/scripts/run_with_hang_watchdog.ps1
@@ -1,0 +1,207 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+<#
+.SYNOPSIS
+    Launches an arbitrary executable (e.g. ctest, a single test exe) alongside the
+    test_hang_watchdog.ps1 watchdog, captures dumps for hung processes, and forwards
+    the executable's exit code.
+
+.DESCRIPTION
+    Designed to be invoked from a CI pipeline task OR from a developer shell. The wrapper:
+      1. Launches the requested executable with the requested arguments and working directory,
+         inheriting stdout/stderr so the surrounding log looks the same as a bare invocation.
+      2. Launches test_hang_watchdog.ps1 as a hidden background process targeting the new pid.
+      3. Waits for the executable to exit, then gives the watchdog a brief grace period to wind down.
+      4. Prints the watchdog's hang_summary.txt (if any) and reports how many dumps were captured.
+      5. Returns the executable's exit code.
+
+    When invoked in an Azure DevOps task, also emits ##vso[] commands so:
+      - A warning shows up in the build summary if any dumps were captured.
+      - The HangDumpsCaptured task variable is set to 'true' (consumed by upload_logs_on_fail.yml
+        to conditionally publish the test_hang_dumps artifact).
+
+.PARAMETER Executable
+    Full path to the executable to run (e.g. ctest.exe, or a single _exe_ebs.exe).
+
+.PARAMETER Arguments
+    Argument string passed to the executable. May contain embedded quotes; passed as-is to
+    System.Diagnostics.ProcessStartInfo.Arguments.
+
+.PARAMETER WorkingDirectory
+    Working directory for the executable. Defaults to the current directory.
+
+.PARAMETER DumpDir
+    Directory where dumps and hang_summary.txt are written. Defaults to
+    "$env:BUILD_ARTIFACTSTAGINGDIRECTORY\test_hang_dumps" when that env var is set,
+    otherwise "$env:TEMP\test_hang_dumps".
+
+.PARAMETER WatchdogScript
+    Full path to test_hang_watchdog.ps1. Defaults to the watchdog next to this script.
+
+.PARAMETER DumpThresholdSec
+    Process age (seconds) at which the watchdog captures a dump. Default 1380.
+
+.PARAMETER PollIntervalSec
+    Watchdog poll interval (seconds). Default 30.
+
+.PARAMETER NamePattern
+    Regex applied to candidate process names. Default '_int_exe_ebs'.
+
+.PARAMETER IncludeWatched
+    If set, the launched executable itself (not just its children) is a dump candidate.
+    Use this when wrapping a single test exe directly, not when wrapping ctest.
+
+.PARAMETER KillAfterDump
+    If set, each candidate process is killed immediately after a successful dump. Intended for
+    single-exe runs so the wrapped exe exits promptly and the artifact-publishing step gets to
+    run before the surrounding ADO job timeout reaps the entire task. Leave false under ctest --
+    killing a child would skip remaining tests and confuse ctest's reporting.
+
+.EXAMPLE
+    # CI-style: wrap a ctest invocation
+    PS> .\run_with_hang_watchdog.ps1 `
+            -Executable 'C:\...\ctest.exe' `
+            -Arguments '-j 16 -C Debug -V --output-on-failure -E _perf' `
+            -WorkingDirectory C:\src\cmake `
+            -DumpThresholdSec 1380
+
+.EXAMPLE
+    # Single-exe: wrap a developer-test invocation, dumping if the test exe itself runs > 60s
+    PS> .\run_with_hang_watchdog.ps1 `
+            -Executable C:\bin\bsi_with_wait_chaos_int_exe_ebs.exe `
+            -DumpThresholdSec 60 -PollIntervalSec 5 -IncludeWatched
+#>
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [string]$Executable,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Arguments = '',
+
+    [Parameter(Mandatory = $false)]
+    [string]$WorkingDirectory = '',
+
+    [Parameter(Mandatory = $false)]
+    [string]$DumpDir = '',
+
+    [Parameter(Mandatory = $false)]
+    [string]$WatchdogScript = '',
+
+    [Parameter(Mandatory = $false)]
+    [int]$DumpThresholdSec = 1380,
+
+    [Parameter(Mandatory = $false)]
+    [int]$PollIntervalSec = 30,
+
+    [Parameter(Mandatory = $false)]
+    [string]$NamePattern = '_exe_',
+
+    [Parameter(Mandatory = $false)]
+    [bool]$IncludeWatched = $false,
+
+    [Parameter(Mandatory = $false)]
+    [bool]$KillAfterDump = $false
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $WorkingDirectory) {
+    $WorkingDirectory = (Get-Location).Path
+}
+
+if (-not $DumpDir) {
+    if ($env:BUILD_ARTIFACTSTAGINGDIRECTORY) {
+        $DumpDir = Join-Path $env:BUILD_ARTIFACTSTAGINGDIRECTORY 'test_hang_dumps'
+    }
+    else {
+        $DumpDir = Join-Path $env:TEMP 'test_hang_dumps'
+    }
+}
+if (-not (Test-Path $DumpDir)) { New-Item -ItemType Directory -Path $DumpDir -Force | Out-Null }
+
+if (-not $WatchdogScript) {
+    $WatchdogScript = Join-Path $PSScriptRoot 'test_hang_watchdog.ps1'
+}
+if (-not (Test-Path $WatchdogScript)) {
+    throw "Watchdog script not found at: $WatchdogScript"
+}
+
+# Resolve executable: accept either a full path or a name on PATH
+$resolvedExecutable = $Executable
+if (-not (Test-Path -LiteralPath $resolvedExecutable -ErrorAction SilentlyContinue)) {
+    $cmd = Get-Command $Executable -ErrorAction SilentlyContinue
+    if ($null -ne $cmd) {
+        $resolvedExecutable = $cmd.Source
+    }
+    else {
+        throw "Executable not found at: $Executable (and not on PATH)"
+    }
+}
+
+Write-Host "Launching: $resolvedExecutable $Arguments"
+
+# Launch the executable with stdout/stderr inherited so the surrounding log is unchanged.
+# System.Diagnostics.Process is cleaner than Start-Process for args containing embedded quotes.
+$psi = New-Object System.Diagnostics.ProcessStartInfo
+$psi.FileName = $resolvedExecutable
+$psi.Arguments = $Arguments
+$psi.UseShellExecute = $false
+$psi.WorkingDirectory = $WorkingDirectory
+$childProc = [System.Diagnostics.Process]::Start($psi)
+
+Write-Host "Child pid: $($childProc.Id) - launching test_hang_watchdog (threshold ${DumpThresholdSec}s, poll ${PollIntervalSec}s, includeWatched=$IncludeWatched, killAfterDump=$KillAfterDump)"
+
+# Start-Process -ArgumentList joins string[] with spaces and does NOT quote individual
+# values, so paths containing spaces would be split into multiple arguments. Build a single
+# argument string with path-valued args pre-quoted to preserve them.
+$watchdogArgs = @(
+    '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+    '-File', "`"$WatchdogScript`"",
+    '-WatchedPid', $childProc.Id,
+    '-DumpDir', "`"$DumpDir`"",
+    '-DumpThresholdSec', $DumpThresholdSec,
+    '-PollIntervalSec', $PollIntervalSec,
+    '-NamePattern', "`"$NamePattern`""
+)
+if ($IncludeWatched) { $watchdogArgs += '-IncludeWatched' }
+if ($KillAfterDump)  { $watchdogArgs += '-KillAfterDump' }
+
+$watchdogProc = Start-Process -FilePath 'powershell.exe' -ArgumentList ($watchdogArgs -join ' ') -PassThru -WindowStyle Hidden
+
+# Block until the wrapped executable finishes.
+$childProc.WaitForExit()
+$childExitCode = $childProc.ExitCode
+Write-Host "Wrapped executable exited with $childExitCode"
+
+# Watchdog now polls for watched-pid-gone every 1s internally, so it should exit within a
+# couple of seconds of the wrapped exe finishing regardless of $PollIntervalSec.
+$watchdogTimeoutMs = 10 * 1000
+if (-not $watchdogProc.WaitForExit($watchdogTimeoutMs)) {
+    Write-Host "Watchdog (pid $($watchdogProc.Id)) did not exit in time; killing it"
+    try { $watchdogProc.Kill() } catch {}
+}
+
+$summaryFile = Join-Path $DumpDir 'hang_summary.txt'
+$dumpCount = 0
+if (Test-Path $summaryFile) {
+    Write-Host "--- test_hang_watchdog summary ---"
+    Get-Content $summaryFile | ForEach-Object { Write-Host $_ }
+    $dumpCount = (Get-ChildItem $DumpDir -Filter '*.dmp' -ErrorAction SilentlyContinue | Measure-Object).Count
+}
+
+# Surface results when running under Azure DevOps.
+if ($env:TF_BUILD) {
+    if ($dumpCount -gt 0) {
+        Write-Host "##vso[task.logissue type=warning]Captured $dumpCount hang dump(s) under $DumpDir; see test_hang_dumps artifact."
+        Write-Host "##vso[task.setvariable variable=HangDumpsCaptured]true"
+    }
+}
+else {
+    if ($dumpCount -gt 0) {
+        Write-Host "WARNING: Captured $dumpCount hang dump(s) under $DumpDir"
+    }
+}
+
+exit $childExitCode

--- a/pipeline_templates/scripts/run_with_hang_watchdog.ps1
+++ b/pipeline_templates/scripts/run_with_hang_watchdog.ps1
@@ -21,7 +21,7 @@
         to conditionally publish the test_hang_dumps artifact).
 
 .PARAMETER Executable
-    Full path to the executable to run (e.g. ctest.exe, or a single _exe_ebs.exe).
+    Full path to the executable to run (e.g. ctest.exe, or a single test exe).
 
 .PARAMETER Arguments
     Argument string passed to the executable. May contain embedded quotes; passed as-is to
@@ -39,13 +39,13 @@
     Full path to test_hang_watchdog.ps1. Defaults to the watchdog next to this script.
 
 .PARAMETER DumpThresholdSec
-    Process age (seconds) at which the watchdog captures a dump. Default 1380.
+    Process age (seconds) at which the watchdog captures a dump. Default 1200.
 
 .PARAMETER PollIntervalSec
     Watchdog poll interval (seconds). Default 30.
 
 .PARAMETER NamePattern
-    Regex applied to candidate process names. Default '_int_exe_ebs'.
+    Regex applied to candidate process names. Default '_exe_'.
 
 .PARAMETER IncludeWatched
     If set, the launched executable itself (not just its children) is a dump candidate.
@@ -63,12 +63,12 @@
             -Executable 'C:\...\ctest.exe' `
             -Arguments '-j 16 -C Debug -V --output-on-failure -E _perf' `
             -WorkingDirectory C:\src\cmake `
-            -DumpThresholdSec 1380
+            -DumpThresholdSec 1200
 
 .EXAMPLE
     # Single-exe: wrap a developer-test invocation, dumping if the test exe itself runs > 60s
     PS> .\run_with_hang_watchdog.ps1 `
-            -Executable C:\bin\bsi_with_wait_chaos_int_exe_ebs.exe `
+            -Executable C:\bin\my_test_int_exe_myproject.exe `
             -DumpThresholdSec 60 -PollIntervalSec 5 -IncludeWatched
 #>
 
@@ -90,7 +90,7 @@ param (
     [string]$WatchdogScript = '',
 
     [Parameter(Mandatory = $false)]
-    [int]$DumpThresholdSec = 1380,
+    [int]$DumpThresholdSec = 1200,
 
     [Parameter(Mandatory = $false)]
     [int]$PollIntervalSec = 30,

--- a/pipeline_templates/scripts/test_hang_watchdog.ps1
+++ b/pipeline_templates/scripts/test_hang_watchdog.ps1
@@ -22,8 +22,7 @@
     Children of this process whose name matches -NamePattern are candidates for dumping.
 
 .PARAMETER DumpThresholdSec
-    Process age (in seconds) at which a dump is captured. Defaults to 1380 (2 minutes under
-    ctest's 1500 s default per-test timeout).
+    Process age (in seconds) at which a dump is captured. Defaults to 1200 (20 minutes).
 
 .PARAMETER DumpDir
     Directory where dumps and the hang_summary.txt log are written.
@@ -33,7 +32,7 @@
 
 .PARAMETER NamePattern
     Regex applied to process Name. Only matching processes are eligible for dumping.
-    Defaults to '_int_exe_ebs'.
+    Defaults to '_exe_'.
 
 .PARAMETER IncludeWatched
     If set, the -WatchedPid itself is also a dump candidate (in addition to its children).
@@ -48,7 +47,7 @@
     killing a child test would corrupt ctest's bookkeeping and skip remaining tests.
 
 .EXAMPLE
-    PS> .\test_hang_watchdog.ps1 -WatchedPid 12345 -DumpDir C:\dumps -DumpThresholdSec 1380
+    PS> .\test_hang_watchdog.ps1 -WatchedPid 12345 -DumpDir C:\dumps -DumpThresholdSec 1200
 #>
 
 [CmdletBinding()]
@@ -60,7 +59,7 @@ param (
     [string]$DumpDir,
 
     [Parameter(Mandatory = $false)]
-    [int]$DumpThresholdSec = 1380,
+    [int]$DumpThresholdSec = 1200,
 
     [Parameter(Mandatory = $false)]
     [int]$PollIntervalSec = 30,

--- a/pipeline_templates/scripts/test_hang_watchdog.ps1
+++ b/pipeline_templates/scripts/test_hang_watchdog.ps1
@@ -1,0 +1,235 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+<#
+.SYNOPSIS
+    Watchdog that captures process dumps of test exes that approach their per-test timeout.
+
+.DESCRIPTION
+    Polls every -PollIntervalSec seconds. While the -WatchedPid is alive, considers a set of
+    candidate processes:
+      - Direct children of -WatchedPid whose process name matches -NamePattern.
+      - The -WatchedPid itself, if -IncludeWatched is set and its name matches -NamePattern
+        (use this when wrapping a single test exe directly).
+    For each candidate, computes age in seconds. When age exceeds -DumpThresholdSec, captures a
+    full-memory dump using awdump.exe (preferred, found via the MonAgentCore install directory)
+    or procdump.exe (fallback - downloaded from sysinternals if not present, signature-checked
+    before being executed).
+
+    Exits cleanly when the watched process exits.
+
+.PARAMETER WatchedPid
+    PID of the process to watch. The watchdog exits when this process is gone.
+    Children of this process whose name matches -NamePattern are candidates for dumping.
+
+.PARAMETER DumpThresholdSec
+    Process age (in seconds) at which a dump is captured. Defaults to 1380 (2 minutes under
+    ctest's 1500 s default per-test timeout).
+
+.PARAMETER DumpDir
+    Directory where dumps and the hang_summary.txt log are written.
+
+.PARAMETER PollIntervalSec
+    How often to poll. Defaults to 30 seconds.
+
+.PARAMETER NamePattern
+    Regex applied to process Name. Only matching processes are eligible for dumping.
+    Defaults to '_int_exe_ebs'.
+
+.PARAMETER IncludeWatched
+    If set, the -WatchedPid itself is also a dump candidate (in addition to its children).
+    Use this when the wrapper launches the test exe directly (single-exe scenario) rather
+    than launching ctest.
+
+.PARAMETER KillAfterDump
+    If set, each candidate process is killed after its dump has been captured. Use this in
+    single-exe scenarios (combined with -IncludeWatched) so the wrapped test exits promptly
+    after we've captured evidence -- otherwise the surrounding ADO job timeout can kill the
+    entire task before the dump artifact gets published. Not appropriate under ctest, where
+    killing a child test would corrupt ctest's bookkeeping and skip remaining tests.
+
+.EXAMPLE
+    PS> .\test_hang_watchdog.ps1 -WatchedPid 12345 -DumpDir C:\dumps -DumpThresholdSec 1380
+#>
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [int]$WatchedPid,
+
+    [Parameter(Mandatory = $true)]
+    [string]$DumpDir,
+
+    [Parameter(Mandatory = $false)]
+    [int]$DumpThresholdSec = 1380,
+
+    [Parameter(Mandatory = $false)]
+    [int]$PollIntervalSec = 30,
+
+    [Parameter(Mandatory = $false)]
+    [string]$NamePattern = '_exe_',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$IncludeWatched,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$KillAfterDump
+)
+
+$ErrorActionPreference = 'Continue'
+
+if (-not (Test-Path $DumpDir)) {
+    New-Item -ItemType Directory -Path $DumpDir -Force | Out-Null
+}
+
+$summaryFile = Join-Path $DumpDir 'hang_summary.txt'
+"=== test_hang_watchdog started at $(Get-Date -Format o) (WatchedPid=$WatchedPid, threshold=${DumpThresholdSec}s, poll=${PollIntervalSec}s, includeWatched=$IncludeWatched, killAfterDump=$KillAfterDump) ===" | Add-Content $summaryFile
+
+# Locate awdump.exe via MonAgentCore install directory
+# Reference: https://eng.ms/docs/products/azure-watson/azurewatson/dumpcreationwithawdump
+function Find-Awdump {
+    try {
+        $monAgent = Get-CimInstance -ClassName Win32_Process -Filter "Name='MonAgentCore.exe'" -ErrorAction Stop |
+            Select-Object -First 1
+        if ($null -eq $monAgent -or [string]::IsNullOrWhiteSpace($monAgent.ExecutablePath)) {
+            return $null
+        }
+        $candidate = Join-Path ([System.IO.Path]::GetDirectoryName($monAgent.ExecutablePath)) 'awdump.exe'
+        if (Test-Path $candidate) { return $candidate } else { return $null }
+    }
+    catch {
+        return $null
+    }
+}
+
+# Locate procdump.exe (PATH first, then download from sysinternals if missing).
+# After download or for a cached copy, verify Authenticode signature is Microsoft-signed.
+function Find-Procdump {
+    $cmd = Get-Command procdump.exe -ErrorAction SilentlyContinue
+    if ($null -ne $cmd) { return $cmd.Source }
+
+    $candidate = Join-Path $DumpDir 'procdump.exe'
+    if (-not (Test-Path $candidate)) {
+        try {
+            Invoke-WebRequest -Uri 'https://live.sysinternals.com/procdump.exe' -OutFile $candidate -UseBasicParsing -ErrorAction Stop
+        }
+        catch {
+            return $null
+        }
+    }
+
+    try {
+        $sig = Get-AuthenticodeSignature -FilePath $candidate -ErrorAction Stop
+        $signerIsMicrosoft = ($null -ne $sig.SignerCertificate) -and ($sig.SignerCertificate.Subject -match 'O=Microsoft Corporation')
+        if ($sig.Status -ne 'Valid' -or -not $signerIsMicrosoft) {
+            "$(Get-Date -Format o) PROCDUMP_SIGCHECK_FAIL path=$candidate status=$($sig.Status) subject=$($sig.SignerCertificate.Subject)" | Add-Content $summaryFile
+            Remove-Item -Path $candidate -Force -ErrorAction SilentlyContinue
+            return $null
+        }
+        return $candidate
+    }
+    catch {
+        "$(Get-Date -Format o) PROCDUMP_SIGCHECK_ERROR path=$candidate err=$($_.Exception.Message)" | Add-Content $summaryFile
+        Remove-Item -Path $candidate -Force -ErrorAction SilentlyContinue
+        return $null
+    }
+}
+
+# Capture a full-memory dump of $procId using whichever tool is available.
+# Returns @{Success; Tool; DumpFile}. On success the dump file is always under $DumpDir
+# so the wrapper can count *.dmp to know whether to publish the artifact.
+function Invoke-Dump {
+    param ([int]$procId, [string]$exeName)
+
+    $dumpFile = Join-Path $DumpDir ("{0}_{1}.dmp" -f $exeName, $procId)
+
+    $awdumpPath = Find-Awdump
+    if ($null -ne $awdumpPath) {
+        # awdump's default destination depends on its configuration; force it to write under $DumpDir
+        # by running it with -WorkingDirectory $DumpDir and then picking up any new *.dmp.
+        $beforeDumps = @(Get-ChildItem -Path $DumpDir -Filter '*.dmp' -File -ErrorAction SilentlyContinue | ForEach-Object { $_.FullName })
+        Start-Process -FilePath $awdumpPath -ArgumentList @('create', $procId, '-bypass') -WorkingDirectory $DumpDir -Wait -NoNewWindow | Out-Null
+        $newDump = Get-ChildItem -Path $DumpDir -Filter '*.dmp' -File -ErrorAction SilentlyContinue |
+            Where-Object { $beforeDumps -notcontains $_.FullName } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+        if ($null -ne $newDump) {
+            if ($newDump.FullName -ne $dumpFile) {
+                Move-Item -Path $newDump.FullName -Destination $dumpFile -Force -ErrorAction SilentlyContinue
+            }
+            $success = (Test-Path $dumpFile) -and ((Get-Item $dumpFile -ErrorAction SilentlyContinue).Length -gt 0)
+            if ($success) {
+                return @{ Success = $true; Tool = 'awdump'; DumpFile = $dumpFile }
+            }
+        }
+        # awdump didn't produce a dump under $DumpDir; fall through to procdump so we still publish something.
+    }
+
+    $procdumpPath = Find-Procdump
+    if ($null -ne $procdumpPath) {
+        # procdump's exit code is the count of dumps written, not 0/1 success. Check the file instead.
+        Start-Process -FilePath $procdumpPath -ArgumentList @('-accepteula', '-ma', $procId, $dumpFile) -Wait -NoNewWindow | Out-Null
+        $success = (Test-Path $dumpFile) -and ((Get-Item $dumpFile).Length -gt 0)
+        return @{ Success = $success; Tool = 'procdump'; DumpFile = $dumpFile }
+    }
+
+    return @{ Success = $false; Tool = 'none'; DumpFile = '' }
+}
+
+$alreadyDumped = New-Object 'System.Collections.Generic.HashSet[int]'
+
+# Inner watched-pid check granularity: how often we poll for the watched pid being gone,
+# independent of how often we re-scan candidates. Keeping this small means the watchdog
+# notices the wrapper's exe finishing within ~1s instead of up to $PollIntervalSec.
+$watchedCheckIntervalSec = 1
+
+while ($true) {
+    # Sleep in $watchedCheckIntervalSec increments up to a full poll tick so we notice the
+    # watched pid is gone quickly even when $PollIntervalSec is large.
+    $elapsedThisTick = 0
+    while ($elapsedThisTick -lt $PollIntervalSec) {
+        Start-Sleep -Seconds $watchedCheckIntervalSec
+        if ($null -eq (Get-Process -Id $WatchedPid -ErrorAction SilentlyContinue)) {
+            "=== watched pid $WatchedPid is gone at $(Get-Date -Format o); exiting ===" | Add-Content $summaryFile
+            return
+        }
+        $elapsedThisTick += $watchedCheckIntervalSec
+    }
+
+    $now = Get-Date
+    $candidates = @(Get-CimInstance -ClassName Win32_Process -Filter "ParentProcessId = $WatchedPid" -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match $NamePattern })
+    if ($IncludeWatched) {
+        $self = Get-CimInstance -ClassName Win32_Process -Filter "ProcessId = $WatchedPid" -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match $NamePattern }
+        if ($null -ne $self) { $candidates += $self }
+    }
+
+    foreach ($p in $candidates) {
+        if ($alreadyDumped.Contains([int]$p.ProcessId)) { continue }
+        if ($null -eq $p.CreationDate) { continue }
+
+        $ageSec = ($now - $p.CreationDate).TotalSeconds
+        if ($ageSec -lt $DumpThresholdSec) { continue }
+
+        "$(Get-Date -Format o) HANG_DETECTED pid=$($p.ProcessId) name=$($p.Name) age=$([math]::Round($ageSec,1))s cmd=$($p.CommandLine)" | Add-Content $summaryFile
+        $result = Invoke-Dump -procId ([int]$p.ProcessId) -exeName ([System.IO.Path]::GetFileNameWithoutExtension($p.Name))
+        "$(Get-Date -Format o) DUMP_RESULT pid=$($p.ProcessId) tool=$($result.Tool) success=$($result.Success) file=$($result.DumpFile)" | Add-Content $summaryFile
+
+        # Mark as dumped regardless of success - we don't want to spam dumps every poll if the tool is broken
+        [void]$alreadyDumped.Add([int]$p.ProcessId)
+
+        # Optionally kill the candidate after dumping so the wrapped exe exits promptly and the
+        # surrounding ADO task gets a chance to publish the dump artifact before the job timeout.
+        # Only do this if the dump itself succeeded -- otherwise we'd lose the hang evidence by
+        # killing a process we couldn't capture.
+        if ($KillAfterDump -and $result.Success) {
+            try {
+                Stop-Process -Id ([int]$p.ProcessId) -Force -ErrorAction Stop
+                "$(Get-Date -Format o) KILLED_AFTER_DUMP pid=$($p.ProcessId)" | Add-Content $summaryFile
+            }
+            catch {
+                "$(Get-Date -Format o) KILL_AFTER_DUMP_FAILED pid=$($p.ProcessId) err=$($_.Exception.Message)" | Add-Content $summaryFile
+            }
+        }
+    }
+}


### PR DESCRIPTION
Moves the hang watchdog from Azure-MessagingStore to c-build-tools so all consuming repos get automatic CI hang protection with zero code changes.

## New files
- `pipeline_templates/scripts/test_hang_watchdog.ps1` — monitors test processes, captures dumps via awdump/procdump when age exceeds threshold
- `pipeline_templates/scripts/run_with_hang_watchdog.ps1` — wrapper that launches executable + watchdog, forwards exit code
- `pipeline_templates/run_with_hang_watchdog.yml` — YAML template for pipeline integration

## Integration
- `build_and_run_tests.yml` — wraps CTest with watchdog when `enable_hang_watchdog` is true (default ON). Falls back to `tasks/ctest.yml` when disabled.
- `build_teardown_steps.yml` — publishes hang dumps as pipeline artifact when captured
- `build_all_flavors.yml` — propagates watchdog parameters

## Parameters
| Parameter | Default | Description |
|-----------|---------|-------------|
| `enable_hang_watchdog` | `true` | Enable/disable watchdog wrapping |
| `hang_watchdog_name_pattern` | `_exe_` | Regex to match test process names |
| `hang_dump_threshold_sec` | `1380` | Process age at which dump is captured |

## Validated
Tested with zrpc PR [#16027755](https://msazure.visualstudio.com/One/_git/zrpc/pullrequest/16027755) — all x64 jobs passed, watchdog correctly wraps ctest and forwards exit codes.
