### PR TITLE
[MrBot][build] Parameterize submodule-checkout retry in run_master_check (Task #38665024)

### DIFF
--- a/pipeline_templates/run_master_check.yml
+++ b/pipeline_templates/run_master_check.yml
@@ -12,6 +12,9 @@ parameters:
   - name: pool_name
     type: string
     default: "Azure-MessagingStore-Win-x64-Dadsv5-v19"
+  - name: submodule_checkout_retry_count # Number of automatic retries for the submodule-fetching checkout/update steps. Defaults to 0 (no retry) so existing consumers are unaffected; set to a small value (e.g. 3) in repos with a large submodule that occasionally fails mid-transfer with a connection reset (curl 56 / early EOF).
+    type: number
+    default: 0
 
 jobs:
 - job: run_master_check
@@ -28,12 +31,20 @@ jobs:
   - checkout: self
     submodules: true
     clean: false
+    # Retry on failure to handle the fetch of a large submodule, which can
+    # occasionally fail mid-transfer with a connection reset (curl 56 / early EOF).
+    # Defaults to 0 (no retry) so other consumers are unaffected.
+    retryCountOnTaskFailure: ${{ parameters.submodule_checkout_retry_count }}
 
   - task: BatchScript@1
     displayName: 'Git submodule update'
     inputs:
       filename: 'C:\Program Files\Git\bin\git.exe'
       arguments: 'submodule update --init --force --jobs 20'
+    # Retry on failure to handle the fetch of a large submodule, which can
+    # occasionally fail mid-transfer with a connection reset (curl 56 / early EOF).
+    # Defaults to 0 (no retry) so other consumers are unaffected.
+    retryCountOnTaskFailure: ${{ parameters.submodule_checkout_retry_count }}
 
   - task: BatchScript@1
     displayName: 'Git submodule clean'


### PR DESCRIPTION
## Summary
Fixes Task #38665024 (https://dev.azure.com/msazure/One/_workitems/edit/38665024).

## Root cause
The ELS gate leg **Run submodule master check** (defined here in `pipeline_templates/run_master_check.yml`) fails intermittently in the built-in **Checkout** (Get Sources) / `Git submodule update` steps: the fetch of the large `deps/block-store` submodule (~595 MiB pack / 232k objects) is reset mid-transfer by the server (`error: RPC failed; curl 56 Recv failure: Connection was reset` -> `fatal: early EOF`). Neither the `checkout: self` (submodules: true) step nor the `Git submodule update` BatchScript step set `retryCountOnTaskFailure`, so a single transient network blip fails the whole leg. This is the same failure mode ELS PR 16293811 fixed in its own YAMLs, but that PR could not touch this template because it lives in the external c-build-tools repo.

## The fix (build-YAML only)
- Add an optional `submodule_checkout_retry_count` parameter (type `number`, default `0`) to `run_master_check.yml`.
- Wire it into the submodule-fetching `checkout: self` step and the `Git submodule update` BatchScript step via `retryCountOnTaskFailure: ${{ parameters.submodule_checkout_retry_count }}`.
- Defaulting to `0` means **no behavior change for any existing consumer** (0 retries == absent). Per the DRI's guidance, ELS will set this parameter to a small value (e.g. `3`) after the `deps/c-build-tools` submodule bump is propagated, so the retry only applies where the large submodule fetch actually occurs. Other repos are unaffected by default.

## Verification
- YAML parse: **PASS**.
- `retryCountOnTaskFailure` on `checkout`/task steps is already used and merged in the sibling ELS PR 16293811, confirming ADO support.
- Original repro: **could not be reproduced locally** — the failure is a server-side TCP connection reset from `msazure.visualstudio.com` during a ~595 MiB submodule transfer on the gate build pool, which cannot be forced from a dev box (same conclusion accepted for precedent PR 16293811). Root cause was established from build logs across 5 independent gate builds with the identical `curl 56 Recv failure / early EOF` signature. Effectiveness is observable as the post-merge "Run submodule master check" Checkout success rate once ELS opts in.

## Follow-up (not in this PR)
- Bump `deps/c-build-tools` submodule pointer in ELS to pick up this template.
- Set `submodule_checkout_retry_count: 3` on the ELS `run_master_check.yml` template call in `build/devops_gated_run_once_passthrough.yml`.

## MrBot session
- Action: `FIX`
- Started: `2026-07-02T14:31:37Z`
- Investigated by MrBot; humans authorised the fix via `/proceed` on the task.
