### PR TITLE
[MrBot][build] Retry git checkout steps on transient network failures

### DIFF
--- a/pipeline_templates/build_linux.yml
+++ b/pipeline_templates/build_linux.yml
@@ -24,6 +24,8 @@ jobs:
   steps:
   # Shallow clone - only need the code at this commit, not full history
   - checkout: self
+    # Retry on failure to handle transient network connection failures (curl 56 / early EOF).
+    retryCountOnTaskFailure: 3
     submodules: false
     clean: false
     fetchDepth: 1

--- a/pipeline_templates/codeql3000_default.yml
+++ b/pipeline_templates/codeql3000_default.yml
@@ -41,6 +41,8 @@ jobs:
 
   # Shallow clone - only need the code at this commit, not full history
   - checkout: self
+    # Retry on failure to handle transient network connection failures (curl 56 / early EOF).
+    retryCountOnTaskFailure: 3
     submodules: false
     clean: false
     fetchDepth: 1

--- a/pipeline_templates/common_setup_steps.yml
+++ b/pipeline_templates/common_setup_steps.yml
@@ -14,6 +14,8 @@ steps:
 
   # submodules: true puts the System.AccessToken on the auth header for every submodule URL (not just the outer repo URL), so consumers with internal-ADO submodules work.
   - checkout: self
+    # Retry on failure to handle transient network connection failures (curl 56 / early EOF).
+    retryCountOnTaskFailure: 3
     submodules: true
     clean: false
     fetchDepth: 1

--- a/pipeline_templates/run_master_check.yml
+++ b/pipeline_templates/run_master_check.yml
@@ -26,6 +26,8 @@ jobs:
 
   steps:
   - checkout: self
+    # Retry on failure to handle transient network connection failures (curl 56 / early EOF).
+    retryCountOnTaskFailure: 3
     submodules: true
     clean: false
 


### PR DESCRIPTION
## Summary
Broadly applies the transient git-checkout retry fix from [ELS PR 16293811](https://msazure.visualstudio.com/One/_git/Azure-Messaging-ElasticLog/pullrequest/16293811) to this repo's pipeline YAML.

Every pipeline `checkout:` step now sets `retryCountOnTaskFailure: 3`, so a transient network failure during Get Sources / submodule fetch (e.g. `curl 56 Recv failure: Connection was reset` -> `fatal: early EOF`) is retried automatically instead of failing the leg.

These are the shared `pipeline_templates/*` consumed by the C-library repos (c-pal, c-util, clds, zrpc, etc.), so this covers checkout retry for all consumers once they pick up the new `c_build_tools` ref.

## Change (build-YAML only)
- Added `retryCountOnTaskFailure: 3` to every git `checkout:` step, each preceded by a brief, consistent comment.

## Verification
- YAML parse: PASS on all changed files.
- Purely additive (2 lines per checkout step, 0 deletions).
