### PR TITLE
Fix use_vcpkg: apply VCPKG_OVERLAY_PORTS before including vcpkg.cmake

### DIFF
--- a/build_functions/CMakeLists.txt
+++ b/build_functions/CMakeLists.txt
@@ -468,6 +468,9 @@ macro(use_vcpkg vcpkgPath)
 
     if (EXISTS ${vcpkgPath}/scripts/buildsystems/vcpkg.cmake)
         set(VCPKG_OVERLAY_TRIPLETS "${build_c_tests_internal_dir}/../vcpkg_triplets/")
+        # VCPKG_OVERLAY_PORTS must be set BEFORE including vcpkg.cmake: the toolchain snapshots it
+        # (and runs the manifest install) at include time, so setting it afterwards has no effect.
+        set(VCPKG_OVERLAY_PORTS "${build_c_tests_internal_dir}/../overlay_ports;${VCPKG_OVERLAY_PORTS}")
         if (${ARCHITECTURE} STREQUAL "x86_64")
             if(${fsanitize_address})
                 set(VCPKG_TARGET_TRIPLET "x64-windows-static-cbt-asan")
@@ -490,8 +493,6 @@ macro(use_vcpkg vcpkgPath)
         endif()
         include(deps/vcpkg/scripts/buildsystems/vcpkg.cmake)
     endif()
-
-    set(VCPKG_OVERLAY_PORTS "${build_c_tests_internal_dir}/../overlay_ports;${VCPKG_OVERLAY_PORTS}")
 endmacro()
 
 function(add_use_vld_if_no_cs target)


### PR DESCRIPTION
## Summary
Fixes a latent bug in the use_vcpkg macro: vcpkg overlay **ports** were silently never applied.

## Details
use_vcpkg set VCPKG_OVERLAY_TRIPLETS **before** include(deps/vcpkg/scripts/buildsystems/vcpkg.cmake) but set VCPKG_OVERLAY_PORTS **after** it. The vcpkg toolchain, during the include(), snapshots VCPKG_OVERLAY_PORTS into a cache variable and runs the manifest install using it. Setting the variable after the include is therefore too late - the manifest install already ran with an empty overlay-ports list. Overlay **triplets** worked only because they were set before the include.

This moves the VCPKG_OVERLAY_PORTS assignment ahead of the include(), mirroring VCPKG_OVERLAY_TRIPLETS.

## Impact / note for reviewers
This activates the overlay ports that were previously silently ignored - currently overlay_ports/pkgconf and overlay_ports/vcpkg-tool-meson. Please confirm those overlays build cleanly (the gate exercises them).

Discovered while debugging a downstream (Azure-MessagingStore) build that relied on an overlay port never taking effect.
