### PR TITLE
[MrBot] Add jemalloc 5.3.0 vcpkg overlay port to pin jemalloc for downstreams

### DIFF
--- a/overlay_ports/jemalloc/.gitattributes
+++ b/overlay_ports/jemalloc/.gitattributes
@@ -1,0 +1,1 @@
+*.patch -text

--- a/overlay_ports/jemalloc/fix-configure-ac.patch
+++ b/overlay_ports/jemalloc/fix-configure-ac.patch
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index f6d25f334..3115504e2 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1592,7 +1592,7 @@ fi
+ [enable_uaf_detection="0"]
+ )
+ if test "x$enable_uaf_detection" = "x1" ; then
+-  AC_DEFINE([JEMALLOC_UAF_DETECTION], [ ])
++  AC_DEFINE([JEMALLOC_UAF_DETECTION], [ ], ["enable UAF"])
+ fi
+ AC_SUBST([enable_uaf_detection])
+ 

--- a/overlay_ports/jemalloc/fix-host-use-libc.patch
+++ b/overlay_ports/jemalloc/fix-host-use-libc.patch
@@ -1,0 +1,13 @@
+diff --git a/include/jemalloc/jemalloc_macros.h.in b/include/jemalloc/jemalloc_macros.h.in
+index ebb3137..05d996b 100644
+--- a/include/jemalloc/jemalloc_macros.h.in
++++ b/include/jemalloc/jemalloc_macros.h.in
+@@ -142,7 +142,7 @@
+ #  define JEMALLOC_COLD
+ #endif
+ 
+-#if (defined(__APPLE__) || defined(__FreeBSD__)) && !defined(JEMALLOC_NO_RENAME)
++#if (defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || (defined(__linux__) && !defined(__GLIBC__))) && !defined(JEMALLOC_NO_RENAME)
+ #  define JEMALLOC_SYS_NOTHROW
+ #else
+ #  define JEMALLOC_SYS_NOTHROW JEMALLOC_NOTHROW

--- a/overlay_ports/jemalloc/portfile.cmake
+++ b/overlay_ports/jemalloc/portfile.cmake
@@ -1,0 +1,58 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO jemalloc/jemalloc
+    REF 54eaed1d8b56b1aa528be3bdd1877e59c56fa90c
+    SHA512 527bfbf5db9a5c2b7b04df4785b6ae9d445cff8cb17298bf3e550c88890d2bd7953642d8efaa417580610508279b527d3a3b9e227d17394fd2013c88cb7ae75a
+    HEAD_REF master
+    PATCHES
+        fix-configure-ac.patch
+        preprocessor.patch
+        fix-host-use-libc.patch # https://github.com/jemalloc/jemalloc/commit/45249cf5a9cfa13c2c62e68e272a391721523b4b
+)
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(opts "ac_cv_search_log=none required" "--without-private-namespace")
+endif()
+
+vcpkg_make_configure(
+    AUTORECONF
+    SOURCE_PATH "${SOURCE_PATH}"
+    DISABLE_MSVC_WRAPPERS
+    DISABLE_MSVC_TRANSFORMATIONS
+    OPTIONS ${opts}
+)
+
+vcpkg_make_install()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    file(COPY "${SOURCE_PATH}/include/msvc_compat/strings.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include/jemalloc/msvc_compat")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/jemalloc/jemalloc.h" "<strings.h>" "\"msvc_compat/strings.h\"")
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/lib/jemalloc.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/bin")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/lib/jemalloc.dll" "${CURRENT_PACKAGES_DIR}/bin/jemalloc.dll")
+    endif()
+    if(NOT VCPKG_BUILD_TYPE)
+        if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+            file(COPY "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-dbg/lib/jemalloc.lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug/lib")
+            file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/bin")
+            file(RENAME "${CURRENT_PACKAGES_DIR}/debug/lib/jemalloc.dll" "${CURRENT_PACKAGES_DIR}/debug/bin/jemalloc.dll")
+        endif()
+    endif()
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/jemalloc.pc" "install_suffix=" "install_suffix=_s")
+        if(NOT VCPKG_BUILD_TYPE)
+            vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/jemalloc.pc" "install_suffix=" "install_suffix=_s")
+        endif()
+    endif()
+endif()
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/tools")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/overlay_ports/jemalloc/preprocessor.patch
+++ b/overlay_ports/jemalloc/preprocessor.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 3115504e2..ffb504b08 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -749,6 +749,7 @@ case "${host}" in
+ 	so="dll"
+ 	if test "x$je_cv_msvc" = "xyes" ; then
+ 	  importlib="lib"
++	  JE_APPEND_VS(CPPFLAGS, -DJEMALLOC_NO_PRIVATE_NAMESPACE)
+ 	  DSO_LDFLAGS="-LD"
+ 	  EXTRA_LDFLAGS="-link -DEBUG"
+ 	  CTARGET='-Fo$@'

--- a/overlay_ports/jemalloc/vcpkg.json
+++ b/overlay_ports/jemalloc/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "jemalloc",
+  "version": "5.3.0",
+  "port-version": 3,
+  "description": "jemalloc is a general purpose malloc(3) implementation that emphasizes fragmentation avoidance and scalable concurrency support",
+  "homepage": "https://jemalloc.net/",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
Adds `overlay_ports/jemalloc` pinning jemalloc to **5.3.0** (REF `54eaed1`), alongside the existing `pkgconf` / `vcpkg-tool-meson` overlays that `use_vcpkg` already wires via `VCPKG_OVERLAY_PORTS`. Downstreams can take vcpkg **2026.06.01** for every other package while keeping jemalloc at 5.3.0.

**Why:** jemalloc 5.3.1 crashes EBS (Azure-MessagingStore) int tests under memory pressure. Dump-proven root cause: under commit exhaustion `arena_choose` returns NULL and `tcache_arena_associate` dereferences it (`&arena->tcache_ql_mtx` at `arena=NULL+0x2F20`) -> AV; downstream tests then `abort()` (0xc0000409). 5.3.0 is green.

The port is the 2026.06.01 jemalloc portfile back-ported to 5.3.0 plus `fix-host-use-libc.patch` (upstream `45249cf5`) required to build 5.3.0. `.patch` files are marked `-text` so they stay LF for vcpkg's `git apply`.

Pairs with Azure/c-pal#631 (restores jemalloc priming, needed on 5.3.0).

Work item 38196464.