### PR TITLE
Fix use_vcpkg: set VCPKG_OVERLAY_PORTS before including vcpkg.cmake (overlay ports were ignored)

### DIFF
--- a/build_functions/CMakeLists.txt
+++ b/build_functions/CMakeLists.txt
@@ -468,6 +468,11 @@ macro(use_vcpkg vcpkgPath)
 
     if (EXISTS ${vcpkgPath}/scripts/buildsystems/vcpkg.cmake)
         set(VCPKG_OVERLAY_TRIPLETS "${build_c_tests_internal_dir}/../vcpkg_triplets/")
+        # VCPKG_OVERLAY_PORTS must be set BEFORE including vcpkg.cmake: the toolchain captures it
+        # into a FORCE cache variable at include time and uses it for the manifest-mode install.
+        # Setting it after the include (as was previously done) is too late - the overlay ports are
+        # silently ignored and the in-tree ports are used instead.
+        set(VCPKG_OVERLAY_PORTS "${build_c_tests_internal_dir}/../overlay_ports;${VCPKG_OVERLAY_PORTS}")
         if (${ARCHITECTURE} STREQUAL "x86_64")
             if(${fsanitize_address})
                 set(VCPKG_TARGET_TRIPLET "x64-windows-static-cbt-asan")
@@ -490,8 +495,6 @@ macro(use_vcpkg vcpkgPath)
         endif()
         include(deps/vcpkg/scripts/buildsystems/vcpkg.cmake)
     endif()
-
-    set(VCPKG_OVERLAY_PORTS "${build_c_tests_internal_dir}/../overlay_ports;${VCPKG_OVERLAY_PORTS}")
 endmacro()
 
 function(add_use_vld_if_no_cs target)


### PR DESCRIPTION
**The overlay-ports mechanism in `use_vcpkg` never actually worked.**

`scripts/buildsystems/vcpkg.cmake` captures `VCPKG_OVERLAY_PORTS` into a `FORCE` cache variable at *include* time (~line 112) and uses it to pass `--overlay-ports` to the manifest-mode install. `use_vcpkg` set `VCPKG_OVERLAY_PORTS` **after** `include(...vcpkg.cmake)`, so it was always empty when the toolchain captured it — overlay ports were silently ignored and the in-tree ports were used.

This is why the jemalloc 5.3.0 overlay (`overlay_ports/jemalloc`, added in #437) had **no effect**: downstream builds still resolved `jemalloc@5.3.1`. `VCPKG_OVERLAY_TRIPLETS` was already set *before* the include (and worked) — which is exactly why the custom triplet applied but the overlay port did not.

**Fix:** move the `VCPKG_OVERLAY_PORTS` assignment next to `VCPKG_OVERLAY_TRIPLETS`, before the include.

Verified locally against Azure-MessagingStore: `vcpkg install jemalloc --overlay-ports=<overlay_ports>` now resolves `jemalloc:x64-windows-static-cbt@5.3.0#3` from the overlay (was silently @5.3.1 without the flag).

Also fixes the (previously latent, unnoticed) `pkgconf` / `vcpkg-tool-meson` overlays in the same directory.

Work item 38196464.