### PR TITLE
[MrBot] Fix Task #38920055: forward AppVerifier ctest filter via env to avoid shell-args validation warning

### DIFF
--- a/pipeline_templates/run_ctests_with_appverifier.yml
+++ b/pipeline_templates/run_ctests_with_appverifier.yml
@@ -1,10 +1,8 @@
 # this template file will run tests under ctest with appverifier enabled
 # it will disable app verifier after running
 # If the list of tests from ctest is filtered, pass the filter arguments as ctest_additional_args so appverifier is enabled for the correct binaries
-# The filter is forwarded to the helper script via the CTEST_ADDITIONAL_ARGS environment
-# variable (not the task 'arguments' input) so that pipe characters in ctest exclusion
-# regexes are not flagged/stripped by the "Enable shell tasks arguments validation" org
-# policy (https://aka.ms/ado/75787). Callers do NOT need to backtick-escape the value.
+# The filter is forwarded via the CTEST_ADDITIONAL_ARGS env var rather than the task 'arguments'
+# input to keep its pipe characters out of shell-args validation (https://aka.ms/ado/75787).
 # The steps in the steps parameter will all be run after enabling app verifier
 #
 # Forwards $(appverifPath) and $(ctestPath) emitted by discover_native_tools.yml
@@ -33,14 +31,6 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1'
-      # The ctest filter is forwarded to the helper via the CTEST_ADDITIONAL_ARGS
-      # environment variable (see the env block below) instead of the -ctestArgs
-      # argument. ctest exclusion regexes contain pipe (|) characters, which are
-      # outside the allow-list enforced by the org-level "Enable shell tasks
-      # arguments validation" policy (https://aka.ms/ado/75787) for a shell task's
-      # 'arguments' input. Keeping the filter out of 'arguments' avoids the warning
-      # today and the regex corruption that would occur if the policy is switched to
-      # enforce. Environment variable values are not subject to that validation.
       arguments: '-on -binaryNameSuffix ${{ parameters.binary_name_suffix }} -appVerifierEnable "${{ parameters.app_verifier_enable }}" -appVerifierAdditionalProperties "${{ parameters.app_verifier_additional_properties }}" -appverifPath "$(appverifPath)" -ctestPath "$(ctestPath)"'
       workingDirectory: ${{ parameters.ctest_tests_bin_directory }}
     env:

--- a/pipeline_templates/run_ctests_with_appverifier.yml
+++ b/pipeline_templates/run_ctests_with_appverifier.yml
@@ -1,6 +1,10 @@
 # this template file will run tests under ctest with appverifier enabled
 # it will disable app verifier after running
 # If the list of tests from ctest is filtered, pass the filter arguments as ctest_additional_args so appverifier is enabled for the correct binaries
+# The filter is forwarded to the helper script via the CTEST_ADDITIONAL_ARGS environment
+# variable (not the task 'arguments' input) so that pipe characters in ctest exclusion
+# regexes are not flagged/stripped by the "Enable shell tasks arguments validation" org
+# policy (https://aka.ms/ado/75787). Callers do NOT need to backtick-escape the value.
 # The steps in the steps parameter will all be run after enabling app verifier
 #
 # Forwards $(appverifPath) and $(ctestPath) emitted by discover_native_tools.yml
@@ -29,8 +33,18 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: '${{ parameters.repo_root }}/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1'
-      arguments: '-on -binaryNameSuffix ${{ parameters.binary_name_suffix }} -ctestArgs "${{ parameters.ctest_additional_args }}" -appVerifierEnable "${{ parameters.app_verifier_enable }}" -appVerifierAdditionalProperties "${{ parameters.app_verifier_additional_properties }}" -appverifPath "$(appverifPath)" -ctestPath "$(ctestPath)"'
+      # The ctest filter is forwarded to the helper via the CTEST_ADDITIONAL_ARGS
+      # environment variable (see the env block below) instead of the -ctestArgs
+      # argument. ctest exclusion regexes contain pipe (|) characters, which are
+      # outside the allow-list enforced by the org-level "Enable shell tasks
+      # arguments validation" policy (https://aka.ms/ado/75787) for a shell task's
+      # 'arguments' input. Keeping the filter out of 'arguments' avoids the warning
+      # today and the regex corruption that would occur if the policy is switched to
+      # enforce. Environment variable values are not subject to that validation.
+      arguments: '-on -binaryNameSuffix ${{ parameters.binary_name_suffix }} -appVerifierEnable "${{ parameters.app_verifier_enable }}" -appVerifierAdditionalProperties "${{ parameters.app_verifier_additional_properties }}" -appverifPath "$(appverifPath)" -ctestPath "$(ctestPath)"'
       workingDirectory: ${{ parameters.ctest_tests_bin_directory }}
+    env:
+      CTEST_ADDITIONAL_ARGS: '${{ parameters.ctest_additional_args }}'
 
   # see https://learn.microsoft.com/en-us/azure/devops/pipelines/process/template-expressions?view=azure-devops#iterative-insertion
   # Also, the magic indenting syntax help from: https://stackoverflow.com/questions/73392651/azure-devops-how-to-add-a-parameter-to-a-step-in-a-steplist

--- a/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
+++ b/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
@@ -25,7 +25,11 @@
   See: https://learn.microsoft.com/en-us/windows-hardware/drivers/devtest/application-verifier-testing-applications#using-the-command-line
 
   .PARAMETER ctestArgs
-  Arguments to pass to ctest. By default ctest is run with "-N" which will just list all tests. This option may be used to filter the tests
+  Arguments to pass to ctest. By default ctest is run with "-N" which will just list all tests. This option may be used to filter the tests.
+  When this parameter is empty, the value of the CTEST_ADDITIONAL_ARGS environment variable is used instead. Pipeline callers
+  (e.g. run_ctests_with_appverifier.yml) forward the filter via that environment variable rather than this argument so that pipe
+  characters in ctest exclusion regexes are not flagged/stripped by the "Enable shell tasks arguments validation" org policy
+  (https://aka.ms/ado/75787), which only inspects a shell task's 'arguments' input.
 
   .PARAMETER binaryNameSuffix
   Suffix for binary names of tests. E.g. if ctest returns some test names like foo, bar, and the binaries are foo_x.exe and bar_x.exe then this should be "_x.exe"
@@ -93,6 +97,22 @@ if ($on)
 {
     Assert-DiscoveredPath -Value $ctestPath -Name "ctestPath"
     Write-Output "Using CTest at: $ctestPath"
+
+    # When -ctestArgs was not supplied, fall back to the CTEST_ADDITIONAL_ARGS
+    # environment variable. Callers forward the ctest filter via env instead of the
+    # task 'arguments' input so that pipe characters in exclusion regexes are not
+    # flagged/stripped by the shell-task arguments-validation policy
+    # (https://aka.ms/ado/75787). Shell-quoting artifacts (escape backticks and double
+    # quotes) that callers previously needed to embed the filter inside the double-quoted
+    # 'arguments' string are removed here: this helper tokenizes on whitespace and passes
+    # each token straight to ctest, so a stray backtick/quote would corrupt the exclusion
+    # regex (e.g. leave the first/last alternative unmatched). Neither character is
+    # meaningful in a ctest test-name regex, so removing them yields the intended filter.
+    if ([string]::IsNullOrWhiteSpace($ctestArgs) -and -not [string]::IsNullOrWhiteSpace($env:CTEST_ADDITIONAL_ARGS))
+    {
+        $ctestArgs = $env:CTEST_ADDITIONAL_ARGS -replace '[`"]', ''
+        Write-Output "Using ctest args from CTEST_ADDITIONAL_ARGS environment variable: $ctestArgs"
+    }
 
     $allTests = & $ctestPath -N $ctestArgs.Split()
     $testsArray = $allTests.Split([Environment]::NewLine,[Stringsplitoptions]::RemoveEmptyEntries).trim()

--- a/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
+++ b/pipeline_templates/scripts/appverifier_ctest_tests_helper.ps1
@@ -26,10 +26,7 @@
 
   .PARAMETER ctestArgs
   Arguments to pass to ctest. By default ctest is run with "-N" which will just list all tests. This option may be used to filter the tests.
-  When this parameter is empty, the value of the CTEST_ADDITIONAL_ARGS environment variable is used instead. Pipeline callers
-  (e.g. run_ctests_with_appverifier.yml) forward the filter via that environment variable rather than this argument so that pipe
-  characters in ctest exclusion regexes are not flagged/stripped by the "Enable shell tasks arguments validation" org policy
-  (https://aka.ms/ado/75787), which only inspects a shell task's 'arguments' input.
+  When empty, falls back to the CTEST_ADDITIONAL_ARGS environment variable.
 
   .PARAMETER binaryNameSuffix
   Suffix for binary names of tests. E.g. if ctest returns some test names like foo, bar, and the binaries are foo_x.exe and bar_x.exe then this should be "_x.exe"
@@ -98,16 +95,9 @@ if ($on)
     Assert-DiscoveredPath -Value $ctestPath -Name "ctestPath"
     Write-Output "Using CTest at: $ctestPath"
 
-    # When -ctestArgs was not supplied, fall back to the CTEST_ADDITIONAL_ARGS
-    # environment variable. Callers forward the ctest filter via env instead of the
-    # task 'arguments' input so that pipe characters in exclusion regexes are not
-    # flagged/stripped by the shell-task arguments-validation policy
-    # (https://aka.ms/ado/75787). Shell-quoting artifacts (escape backticks and double
-    # quotes) that callers previously needed to embed the filter inside the double-quoted
-    # 'arguments' string are removed here: this helper tokenizes on whitespace and passes
-    # each token straight to ctest, so a stray backtick/quote would corrupt the exclusion
-    # regex (e.g. leave the first/last alternative unmatched). Neither character is
-    # meaningful in a ctest test-name regex, so removing them yields the intended filter.
+    # Fall back to the env var used by pipeline callers (keeps pipe chars out of shell-args
+    # validation, https://aka.ms/ado/75787). Strip backticks/double-quotes: shell-quoting
+    # artifacts that are never meaningful in a ctest regex but would otherwise corrupt the filter.
     if ([string]::IsNullOrWhiteSpace($ctestArgs) -and -not [string]::IsNullOrWhiteSpace($env:CTEST_ADDITIONAL_ARGS))
     {
         $ctestArgs = $env:CTEST_ADDITIONAL_ARGS -replace '[`"]', ''


### PR DESCRIPTION
## Summary
The **Enable AppVerifier** step in `pipeline_templates/run_ctests_with_appverifier.yml` embedded the ctest exclusion filter directly in the PowerShell task's `arguments` input (`-ctestArgs "..."`). ctest exclusion regexes contain `|` pipe characters, which are outside the allow-list enforced by the org-level **"Enable shell tasks arguments validation"** policy ([aka.ms/ado/75787](https://aka.ms/ado/75787)). This produced a build warning on every leg that filters tests, and — if the policy is switched from *warn* to *enforce* — the agent would replace each pipe with `_#removed#_`, corrupting the exclusion regex and enabling AppVerifier for the excluded heavy integration suites (likely hangs/timeouts, a future hard gate break).

Fixes Azure DevOps Task **#38920055** — https://msazure.visualstudio.com/One/_workitems/edit/38920055

## Root cause
- The policy validates the `arguments` input of shell tasks against an allow-list and warns on every character outside it (letters, digits, backtick, space, `_ ' " - = / : . \`).
- `run_ctests_with_appverifier.yml` built the Enable AppVerifier arguments as `… -ctestArgs "${{ parameters.ctest_additional_args }}" …`.
- Consumers pass a pipe-separated ctest exclusion regex there (e.g. Azure-Messaging-ElasticLog passes `-E "suiteA|suiteB|…"` covering 10 suites). The `|` characters are the only chars outside the allow-list, so they alone trigger the warning (reproduced: 9 pipes flagged).

## The fix
1. **`run_ctests_with_appverifier.yml`** — forward the filter to the helper via the `CTEST_ADDITIONAL_ARGS` **environment variable** instead of the `-ctestArgs` argument. Environment values are not subject to the shell-args validation, so the pipes are no longer flagged. The `arguments` input no longer contains the filter.
2. **`appverifier_ctest_tests_helper.ps1`** — when `-ctestArgs` is empty, fall back to `$env:CTEST_ADDITIONAL_ARGS`. Shell-quoting artifacts (escape backticks and double quotes that callers previously needed to embed the value inside the double-quoted `arguments` string) are stripped so the filter reaches ctest as a clean exclusion regex.

Callers no longer need to backtick-escape the value. This is **backward compatible** with existing callers (`build_and_run_tests.yml`'s `-E <list>` and the README's `-R my_test_1` both tokenize identically), and is a **strict improvement**: previously the embedded value reached ctest with stray backticks that left the first/last alternative unmatched; the filter is now the intended clean regex, so all listed suites are excluded as designed.

## Verification
This is a pipeline-hygiene defect that manifests in the ADO agent, so it was verified by faithfully reproducing the agent behavior locally (the ADO pipeline itself cannot run outside the gate):
- **Args sanitizer repro** (reimplemented the agent allow-list): the **old** `arguments` string flags `{'|': 9}`; the **new** `arguments` string flags **0** characters.
- **Filter fidelity** (`powershell.exe -File` launched via .NET `Process`, exactly as the agent launches the task): the new env path yields ctest tokens `-E` + `suiteA|…|suiteN` — the intended clean exclusion regex — for the exact ElasticLog value, with no stray quotes/backticks. The other known callers tokenize unchanged.
- **Syntax**: `run_ctests_with_appverifier.yml` parses as valid YAML (`env` block present, `-ctestArgs` removed from `arguments`); `appverifier_ctest_tests_helper.ps1` parses with no errors via the PowerShell AST parser.

## Consumer note (optional, not required)
Repos that previously backtick-escaped this value (e.g. Azure-Messaging-ElasticLog's `run_tests.yml`) may simplify it to the plain `-E …` form when they pick up this change, but do **not** need to — the helper normalizes either form.
